### PR TITLE
Bug 43303: In edge there is a giant X in the ticket search on click blur

### DIFF
--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -116,3 +116,7 @@ div#app {
   }
 
 }
+
+::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
Seems the default "clear field" X that appears inside the right border of text fields is not very compatible with material-ui. In Chrome and Firefox it is hidden by default, but in Edge it shows larger than expected.
This fix makes Edge behave the same as Chrome and Firefox, it will hide the X.