### PR TITLE
Maintenance/authentication library update

### DIFF
--- a/cfg/defaultConstants.js
+++ b/cfg/defaultConstants.js
@@ -14,6 +14,8 @@ module.exports = {
 
     ticketRefreshIntervalInSeconds: 300,
 
+    authVersion: "'ADAL'",
+
 //   Leave this as is if your code is in a public repo (or delete it if you want).  You can override the defaults with the real information in your cfg/$env.const.js file.  
 
     aadTenant: "'Your Azure Active Directory tenant here'", //Yes, use both single and double quotes.

--- a/cfg/defaultConstants.js
+++ b/cfg/defaultConstants.js
@@ -18,7 +18,7 @@ module.exports = {
 
 //   Leave this as is if your code is in a public repo (or delete it if you want).  You can override the defaults with the real information in your cfg/$env.const.js file.  
 
-    aadInstance: "'Your Azure Active Directory instance here'", //Yes, use both single and double quotes.
+    aadInstance: "'https://login.microsoftonline.com/'", //Replace only if using AAD non-public instances. Yes, use both single and double quotes.
 
     aadTenant: "'Your Azure Active Directory tenant here'", //Yes, use both single and double quotes.
 

--- a/cfg/dev.js
+++ b/cfg/dev.js
@@ -31,7 +31,8 @@ let config = Object.assign({}, baseConfig, {
       'RETRY_MAX_TIMEOUT': constants.retryMaxTimeoutInMiliseconds,
       'TICKET_REFRESH_INTERVAL': constants.ticketRefreshIntervalInSeconds,
       'AAD_TENANT': constants.aadTenant,
-      'CLIENT_ID': constants.clientId
+      'CLIENT_ID': constants.clientId,
+      'AUTH_VERSION': constants.authVersion
     })
   ],
   module: defaultSettings.getDefaultModules()

--- a/cfg/dist.js
+++ b/cfg/dist.js
@@ -27,7 +27,8 @@ let config = Object.assign({}, baseConfig, {
       'RETRY_MAX_TIMEOUT': constants.retryMaxTimeoutInMiliseconds,
       'TICKET_REFRESH_INTERVAL': constants.ticketRefreshIntervalInSeconds,
       'AAD_TENANT': constants.aadTenant,
-      'CLIENT_ID': constants.clientId
+      'CLIENT_ID': constants.clientId,
+      'AUTH_VERSION': constants.authVersion
     }),
     new BowerWebpackPlugin({
       searchResolveModulesDirectories: false

--- a/cfg/localhost.js
+++ b/cfg/localhost.js
@@ -31,7 +31,8 @@ let config = Object.assign({}, baseConfig, {
       'RETRY_MAX_TIMEOUT': constants.retryMaxTimeoutInMiliseconds,
       'TICKET_REFRESH_INTERVAL': constants.ticketRefreshIntervalInSeconds,
       'AAD_TENANT': constants.aadTenant,
-      'CLIENT_ID': constants.clientId
+      'CLIENT_ID': constants.clientId,
+      'AUTH_VERSION': constants.authVersion
     })
   ],
   module: defaultSettings.getDefaultModules()

--- a/cfg/test.js
+++ b/cfg/test.js
@@ -54,7 +54,8 @@ var config = {
       'RETRY_MAX_TIMEOUT': constants.retryMaxTimeoutInMiliseconds,
       'TICKET_REFRESH_INTERVAL': constants.ticketRefreshIntervalInSeconds,
       'AAD_TENANT': constants.aadTenant,
-      'CLIENT_ID': constants.clientId
+      'CLIENT_ID': constants.clientId,
+      'AUTH_VERSION': constants.authVersion
     })
   ],
 

--- a/cfg/test.js
+++ b/cfg/test.js
@@ -1,15 +1,14 @@
 'use strict'
 
-let webpack = require('webpack')
-let nodeExternals = require('webpack-node-externals')
-let WebpackShellPlugin = require('webpack-shell-plugin')
-let baseConfig = require('./base')
+var webpack = require('webpack')
+var nodeExternals = require('webpack-node-externals')
+var WebpackShellPlugin = require('webpack-shell-plugin')
 let defaultSettings = require('./defaults')
 let constants = require('./test.const')
 
-let testStandinFor = (variableName) => 'Test Standin For ' + variableName
+var testStandinFor = (variableName) => 'Test Standin For ' + variableName
 
-let config = Object.assign({}, baseConfig, {
+var config = {
   entry: './test/loadtests.js',
   output: {
     filename: 'temp/testBundle.js'
@@ -46,13 +45,7 @@ let config = Object.assign({}, baseConfig, {
     new WebpackShellPlugin({
       onBuildExit: "mocha temp/testBundle.js"
     }),
-    new webpack.DefinePlugin(Object.assign(
-      {},
-      constants,
-      {
-          authVersion: "'TEST'"
-      }
-  ))
+    new webpack.DefinePlugin({constants})
   ],
 
   resolve: {
@@ -67,6 +60,6 @@ let config = Object.assign({}, baseConfig, {
       'react/lib/ReactMount': 'react-dom/lib/ReactMount'
     }
   },
-})
+}
 
 module.exports = config

--- a/cfg/test.js
+++ b/cfg/test.js
@@ -1,14 +1,15 @@
 'use strict'
 
-var webpack = require('webpack')
-var nodeExternals = require('webpack-node-externals')
-var WebpackShellPlugin = require('webpack-shell-plugin')
+let webpack = require('webpack')
+let nodeExternals = require('webpack-node-externals')
+let WebpackShellPlugin = require('webpack-shell-plugin')
+let baseConfig = require('./base')
 let defaultSettings = require('./defaults')
 let constants = require('./test.const')
 
-var testStandinFor = (variableName) => 'Test Standin For ' + variableName
+let testStandinFor = (variableName) => 'Test Standin For ' + variableName
 
-var config = {
+let config = Object.assign({}, baseConfig, {
   entry: './test/loadtests.js',
   output: {
     filename: 'temp/testBundle.js'
@@ -45,7 +46,13 @@ var config = {
     new WebpackShellPlugin({
       onBuildExit: "mocha temp/testBundle.js"
     }),
-    new webpack.DefinePlugin({constants})
+    new webpack.DefinePlugin(Object.assign(
+      {},
+      constants,
+      {
+          authVersion: "'TEST'"
+      }
+  ))
   ],
 
   resolve: {
@@ -60,6 +67,6 @@ var config = {
       'react/lib/ReactMount': 'react-dom/lib/ReactMount'
     }
   },
-}
+})
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@aspnet/signalr-client": "^1.0.0-alpha1-final",
-    "adal-angular": "^1.0.14",
+    "adal-angular": "^1.0.15",
     "cross-env": "^5.0.0",
     "express": "^4.15.2",
     "msal": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "adal-angular": "^1.0.14",
     "cross-env": "^5.0.0",
     "express": "^4.15.2",
+    "msal": "^0.1.3",
     "msgpack5": "^3.5.1",
     "object-path": "^0.11.4",
     "object-path-immutable": "^0.5.2",

--- a/src/actions/actionHelpers.js
+++ b/src/actions/actionHelpers.js
@@ -7,7 +7,7 @@ export const reduxBackedPromise = (promiseGenerator, promiseArgs, actionSet) => 
 
     dispatch(actionSet.try())
 
-    return promiseGenerator(...promiseArgs)
+    return promiseGenerator(dispatch, ...promiseArgs)
         .then(({json, response}) => dispatch(actionSet.succeed(json, response)),
             error => dispatch(actionSet.fail(error)))
 }

--- a/src/actions/actionHelpers.js
+++ b/src/actions/actionHelpers.js
@@ -1,9 +1,25 @@
+import { authenticatedFetch, authenticatedPost, authenticatedPut } from '../services/authenticatedFetch'
+
 const needOnActionSet = (prop) => `Need "${prop}" function on actionSet!`
 
-export const reduxBackedPromise = (promiseGenerator, promiseArgs, actionSet) => (dispatch) => {
+export const reduxBackedPromise = (promiseArgs, actionSet, operation = 'get') => (dispatch) => {
     if(!actionSet.try) { throw needOnActionSet('try')}
     if(!actionSet.succeed) { throw needOnActionSet('succeed')}
     if(!actionSet.fail) { throw needOnActionSet('fail')}
+
+    let promiseGenerator
+    switch (operation.toLowerCase()) {
+        case 'put':
+            promiseGenerator = authenticatedPut
+            break
+        case 'post':
+            promiseGenerator = authenticatedPost
+            break
+        default:
+            promiseGenerator = authenticatedFetch
+            break
+    }
+    if(!promiseGenerator) { throw 'promiseGenerator not initialized. This should not be possible. Consider rolling back.' }
 
     dispatch(actionSet.try())
 

--- a/src/actions/actionHelpers.js
+++ b/src/actions/actionHelpers.js
@@ -2,17 +2,17 @@ import { authenticatedFetch, authenticatedPost, authenticatedPut } from '../serv
 
 const needOnActionSet = (prop) => `Need "${prop}" function on actionSet!`
 
-export const reduxBackedPromise = (promiseArgs, actionSet, operation = 'get') => (dispatch) => {
+export const reduxBackedPromise = (promiseArgs, actionSet, operation = 'GET') => (dispatch) => {
     if(!actionSet.try) { throw needOnActionSet('try')}
     if(!actionSet.succeed) { throw needOnActionSet('succeed')}
     if(!actionSet.fail) { throw needOnActionSet('fail')}
 
     let promiseGenerator
-    switch (operation.toLowerCase()) {
-        case 'put':
+    switch (operation.toUpperCase()) {
+        case 'PUT':
             promiseGenerator = authenticatedPut
             break
-        case 'post':
+        case 'POST':
             promiseGenerator = authenticatedPost
             break
         default:

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -1,30 +1,7 @@
-import GetAuthContext from '../services/msalService'
-
 export const LOGIN_IN_PROGRESS = 'LOGIN_IN_PROGRESS'
 export const USER_LOGGED_IN = 'USER_LOGGED_IN'
 export const USER_LOGGED_OUT = 'USER_LOGGED_OUT'
 export const USER_LOGIN_ERROR = 'USER_LOGIN_ERROR'
-
-export const onLogoutActions = (dispatch) => {
-    dispatch(userLoggedOut())
-    GetAuthContext().logOut()
-}
-
-export const startLogin = (dispatch) => {
-    dispatch(loginInProgress())
-    if(typeof window !== 'undefined' && !!window)
-    {
-        GetAuthContext().loginPopup()
-        .then(
-            () => dispatch(userLoggedIn(GetAuthContext().getUser())),
-            err => dispatch(userLoginError(err))
-        )
-    }
-    else
-    {
-        dispatch(userLoginError('Window is undefined, so MSAL cannot function!'))
-    }
-}
 
 export const loginInProgress = () => ({
     type: LOGIN_IN_PROGRESS

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -1,21 +1,29 @@
+import GetAuthContext from '../services/msalService'
+
 export const LOGIN_IN_PROGRESS = 'LOGIN_IN_PROGRESS'
 export const USER_LOGGED_IN = 'USER_LOGGED_IN'
 export const USER_LOGGED_OUT = 'USER_LOGGED_OUT'
 export const USER_LOGIN_ERROR = 'USER_LOGIN_ERROR'
 
-export const onLoginActions = (siaContext) => (dispatch) => {
-    const user = siaContext.authContext.getCachedUser()
-    dispatch(userLoggedIn(user))
-}
-
-export const onLogoutActions = (authContext) => (dispatch) => {
+export const onLogoutActions = (dispatch) => {
     dispatch(userLoggedOut())
-    authContext.logOut()
+    GetAuthContext().logOut()
 }
 
-export const startLogin = (authContext) => (dispatch) => {
+export const startLogin = (dispatch) => {
     dispatch(loginInProgress())
-    authContext.login()
+    if(typeof window !== 'undefined' && !!window)
+    {
+        GetAuthContext().loginPopup()
+        .then(
+            () => dispatch(userLoggedIn(GetAuthContext().getUser())),
+            err => dispatch(userLoginError(err))
+        )
+    }
+    else
+    {
+        dispatch(userLoginError('Window is undefined, so MSAL cannot function!'))
+    }
 }
 
 export const loginInProgress = () => ({

--- a/src/actions/engagementActions.js
+++ b/src/actions/engagementActions.js
@@ -10,26 +10,26 @@ export const DISENGAGE_SUCCESS = 'DISENGAGE_SUCCESS'
 export const DISENGAGE_FAILURE = 'DISENGAGE_FAILURE'
 export const ENGAGEMENTS = 'ENGAGEMENTS'
 
-export const engagementActions = ({
-    engage: (incidentId, participant, timeEngaged = moment()) =>
-    reduxBackedPromise(
-        authenticatedPost,
-        ['incidents/' + incidentId + '/engagements/', {participant}],
-        engageActionSet(incidentId, participant, timeEngaged)
-    ),
+
+export const engage = (incidentId, participant, timeEngaged = moment()) =>
+reduxBackedPromise(
+    authenticatedPost,
+    ['incidents/' + incidentId + '/engagements/', {participant}],
+    engageActionSet(incidentId, participant, timeEngaged)
+)
     
-    disengage: (participant, engagement, timeDisengaged = moment()) =>
-    reduxBackedPromise(
-        authenticatedPut,
-        [
-            'incidents/' + engagement.incidentId + '/engagements/' + engagement.id,
-            updatedEngagement(engagement, timeDisengaged),
-            null,
-            false
-        ],
-        disengageActionSet(engagement.incidentId, participant, engagement, timeDisengaged)
-    )
-})
+export const disengage = (participant, engagement, timeDisengaged = moment()) =>
+reduxBackedPromise(
+    authenticatedPut,
+    [
+        'incidents/' + engagement.incidentId + '/engagements/' + engagement.id,
+        updatedEngagement(engagement, timeDisengaged),
+        null,
+        false
+    ],
+    disengageActionSet(engagement.incidentId, participant, engagement, timeDisengaged)
+)
+
 
 const engageActionSet = (incidentId, participant, timeEngaged) => ({
     try: () => ({
@@ -79,5 +79,3 @@ const disengageActionSet = (incidentId, participant, engagement, timeDisengaged)
 })
 
 export const pagination = paginationActions(ENGAGEMENTS)
-
-export default engagementActions

--- a/src/actions/engagementActions.js
+++ b/src/actions/engagementActions.js
@@ -1,5 +1,4 @@
 import moment from 'moment'
-import { authenticatedPost, authenticatedPut } from '../services/authenticatedFetch'
 import { reduxBackedPromise, paginationActions } from './actionHelpers'
 
 export const TRY_ENGAGE = 'TRY_ENGAGE'
@@ -13,21 +12,21 @@ export const ENGAGEMENTS = 'ENGAGEMENTS'
 
 export const engage = (incidentId, participant, timeEngaged = moment()) =>
 reduxBackedPromise(
-    authenticatedPost,
     ['incidents/' + incidentId + '/engagements/', {participant}],
-    engageActionSet(incidentId, participant, timeEngaged)
+    engageActionSet(incidentId, participant, timeEngaged),
+    'post'
 )
     
 export const disengage = (participant, engagement, timeDisengaged = moment()) =>
 reduxBackedPromise(
-    authenticatedPut,
     [
         'incidents/' + engagement.incidentId + '/engagements/' + engagement.id,
         updatedEngagement(engagement, timeDisengaged),
         null,
         false
     ],
-    disengageActionSet(engagement.incidentId, participant, engagement, timeDisengaged)
+    disengageActionSet(engagement.incidentId, participant, engagement, timeDisengaged),
+    'put'
 )
 
 

--- a/src/actions/engagementActions.js
+++ b/src/actions/engagementActions.js
@@ -10,17 +10,17 @@ export const DISENGAGE_SUCCESS = 'DISENGAGE_SUCCESS'
 export const DISENGAGE_FAILURE = 'DISENGAGE_FAILURE'
 export const ENGAGEMENTS = 'ENGAGEMENTS'
 
-export const engagementActions = (siaContext) => ({
+export const engagementActions = ({
     engage: (incidentId, participant, timeEngaged = moment()) =>
     reduxBackedPromise(
-        authenticatedPost(siaContext),
+        authenticatedPost,
         ['incidents/' + incidentId + '/engagements/', {participant}],
         engageActionSet(incidentId, participant, timeEngaged)
     ),
     
     disengage: (participant, engagement, timeDisengaged = moment()) =>
     reduxBackedPromise(
-        authenticatedPut(siaContext),
+        authenticatedPut,
         [
             'incidents/' + engagement.incidentId + '/engagements/' + engagement.id,
             updatedEngagement(engagement, timeDisengaged),

--- a/src/actions/engagementActions.js
+++ b/src/actions/engagementActions.js
@@ -14,7 +14,7 @@ export const engage = (incidentId, participant, timeEngaged = moment()) =>
 reduxBackedPromise(
     ['incidents/' + incidentId + '/engagements/', {participant}],
     engageActionSet(incidentId, participant, timeEngaged),
-    'post'
+    'POST'
 )
     
 export const disengage = (participant, engagement, timeDisengaged = moment()) =>
@@ -26,7 +26,7 @@ reduxBackedPromise(
         false
     ],
     disengageActionSet(engagement.incidentId, participant, engagement, timeDisengaged),
-    'put'
+    'PUT'
 )
 
 

--- a/src/actions/eventActions.js
+++ b/src/actions/eventActions.js
@@ -1,7 +1,6 @@
 import moment from 'moment'
 import { paginationActions, updatePagination } from './actionHelpers'
 import { reduxBackedPromise } from './actionHelpers'
-import { authenticatedFetch, authenticatedPost } from '../services/authenticatedFetch'
 
 export const EVENTS = 'EVENTS'
 export const REQUEST_EVENT = 'REQUEST_EVENT'
@@ -20,19 +19,16 @@ export const linksHeaderName = 'links'
 
 
 export const fetchEvent = (incidentId, eventId) => reduxBackedPromise(
-    authenticatedFetch,
     [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/' + eventId],
     getEventActionSet(incidentId, eventId)
 )
 
 export const fetchEvents = (incidentId) => reduxBackedPromise(
-    authenticatedFetch,
     [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/'],
     getEventsActionSet(incidentId)
 )
 
 export const postEvent = (incidentId, eventTypeId = 0, data= {}, occurrenceTime = moment()) => reduxBackedPromise(
-    authenticatedPost,
     [
         (incidentId ? 'incidents/' + incidentId + '/': '') + 'events/',
         {
@@ -42,7 +38,8 @@ export const postEvent = (incidentId, eventTypeId = 0, data= {}, occurrenceTime 
             data
         }
     ],
-    postEventActionSet(incidentId)
+    postEventActionSet(incidentId),
+    'post'
 )
 
 
@@ -94,7 +91,6 @@ export const getEventsActionSet = (incidentId) => ({
 
         if(linksHeader.NextPageLink){
             dispatch(reduxBackedPromise(
-                authenticatedFetch,
                 [linksHeader.NextPageLink],
                 getEventsActionSet(incidentId)
             ))

--- a/src/actions/eventActions.js
+++ b/src/actions/eventActions.js
@@ -39,7 +39,7 @@ export const postEvent = (incidentId, eventTypeId = 0, data= {}, occurrenceTime 
         }
     ],
     postEventActionSet(incidentId),
-    'post'
+    'POST'
 )
 
 

--- a/src/actions/eventActions.js
+++ b/src/actions/eventActions.js
@@ -18,33 +18,33 @@ export const ADD_EVENT = 'ADD_EVENT'
 export const pagination = paginationActions(EVENTS)
 export const linksHeaderName = 'links'
 
-export const eventActions =({
-    fetchEvent: (incidentId, eventId) => reduxBackedPromise(
-        authenticatedFetch,
-        [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/' + eventId],
-        getEventActionSet(incidentId, eventId)
-    ),
 
-    fetchEvents: (incidentId) => reduxBackedPromise(
-        authenticatedFetch,
-        [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/'],
-        getEventsActionSet(incidentId)
-    ),
+export const fetchEvent = (incidentId, eventId) => reduxBackedPromise(
+    authenticatedFetch,
+    [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/' + eventId],
+    getEventActionSet(incidentId, eventId)
+)
 
-    postEvent: (incidentId, eventTypeId = 0, data= {}, occurrenceTime = moment()) => reduxBackedPromise(
-        authenticatedPost,
-        [
-            (incidentId ? 'incidents/' + incidentId + '/': '') + 'events/',
-            {
-                eventTypeId,
-                occurred: occurrenceTime,
-                eventFired: occurrenceTime,
-                data
-            }
-        ],
-        postEventActionSet(incidentId)
-    )
-})
+export const fetchEvents = (incidentId) => reduxBackedPromise(
+    authenticatedFetch,
+    [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/'],
+    getEventsActionSet(incidentId)
+)
+
+export const postEvent = (incidentId, eventTypeId = 0, data= {}, occurrenceTime = moment()) => reduxBackedPromise(
+    authenticatedPost,
+    [
+        (incidentId ? 'incidents/' + incidentId + '/': '') + 'events/',
+        {
+            eventTypeId,
+            occurred: occurrenceTime,
+            eventFired: occurrenceTime,
+            data
+        }
+    ],
+    postEventActionSet(incidentId)
+)
+
 
 export const getEventActionSet = (incidentId, eventId) => ({
     try: () => ({
@@ -139,6 +139,3 @@ export const postEventActionSet = (incidentId) => ({
         failureReason
     })
 })
-
-
-export default eventActions

--- a/src/actions/eventActions.js
+++ b/src/actions/eventActions.js
@@ -18,21 +18,21 @@ export const ADD_EVENT = 'ADD_EVENT'
 export const pagination = paginationActions(EVENTS)
 export const linksHeaderName = 'links'
 
-export const eventActions = (siaContext) => ({
+export const eventActions =({
     fetchEvent: (incidentId, eventId) => reduxBackedPromise(
-        authenticatedFetch(siaContext),
+        authenticatedFetch,
         [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/' + eventId],
         getEventActionSet(incidentId, eventId)
     ),
 
     fetchEvents: (incidentId) => reduxBackedPromise(
-        authenticatedFetch(siaContext),
+        authenticatedFetch,
         [(incidentId ? 'incidents/' + incidentId + '/': '') + 'events/'],
-        getEventsActionSet(siaContext)(incidentId)
+        getEventsActionSet(incidentId)
     ),
 
     postEvent: (incidentId, eventTypeId = 0, data= {}, occurrenceTime = moment()) => reduxBackedPromise(
-        authenticatedPost(siaContext),
+        authenticatedPost,
         [
             (incidentId ? 'incidents/' + incidentId + '/': '') + 'events/',
             {
@@ -70,7 +70,7 @@ export const getEventActionSet = (incidentId, eventId) => ({
     })
 })
 
-export const getEventsActionSet = (siaContext) => (incidentId) => ({
+export const getEventsActionSet = (incidentId) => ({
     try: () => ({
         type: REQUEST_EVENTS,
         incidentId
@@ -94,9 +94,9 @@ export const getEventsActionSet = (siaContext) => (incidentId) => ({
 
         if(linksHeader.NextPageLink){
             dispatch(reduxBackedPromise(
-                authenticatedFetch(siaContext),
+                authenticatedFetch,
                 [linksHeader.NextPageLink],
-                getEventsActionSet(siaContext)(incidentId)
+                getEventsActionSet(incidentId)
             ))
         }
         else{

--- a/src/actions/eventTypeActions.js
+++ b/src/actions/eventTypeActions.js
@@ -1,5 +1,4 @@
 import { reduxBackedPromise } from './actionHelpers'
-import { authenticatedFetch } from '../services/authenticatedFetch'
 
 export const TRY_GET_EVENT_TYPE = 'TRY_GET_EVENT_TYPE'
 export const GET_EVENT_TYPE_SUCCESS = 'GET_EVENT_TYPE_SUCCESS'
@@ -7,7 +6,6 @@ export const GET_EVENT_TYPE_FAILURE = 'GET_EVENT_TYPE_FAILURE'
 
 
 export const fetchEventType = (eventTypeId) => reduxBackedPromise(
-    authenticatedFetch,
     ['eventTypes/' + eventTypeId],
     getEventTypeActionSet(eventTypeId)
 )

--- a/src/actions/eventTypeActions.js
+++ b/src/actions/eventTypeActions.js
@@ -5,9 +5,9 @@ export const TRY_GET_EVENT_TYPE = 'TRY_GET_EVENT_TYPE'
 export const GET_EVENT_TYPE_SUCCESS = 'GET_EVENT_TYPE_SUCCESS'
 export const GET_EVENT_TYPE_FAILURE = 'GET_EVENT_TYPE_FAILURE'
 
-export const eventTypeActions = (siaContext) => ({
+export const eventTypeActions = ({
     fetchEventType: (eventTypeId) => reduxBackedPromise(
-        authenticatedFetch(siaContext),
+        authenticatedFetch,
         ['eventTypes/' + eventTypeId],
         getEventTypeActionSet(eventTypeId)
     )

--- a/src/actions/eventTypeActions.js
+++ b/src/actions/eventTypeActions.js
@@ -5,13 +5,13 @@ export const TRY_GET_EVENT_TYPE = 'TRY_GET_EVENT_TYPE'
 export const GET_EVENT_TYPE_SUCCESS = 'GET_EVENT_TYPE_SUCCESS'
 export const GET_EVENT_TYPE_FAILURE = 'GET_EVENT_TYPE_FAILURE'
 
-export const eventTypeActions = ({
-    fetchEventType: (eventTypeId) => reduxBackedPromise(
-        authenticatedFetch,
-        ['eventTypes/' + eventTypeId],
-        getEventTypeActionSet(eventTypeId)
-    )
-})
+
+export const fetchEventType = (eventTypeId) => reduxBackedPromise(
+    authenticatedFetch,
+    ['eventTypes/' + eventTypeId],
+    getEventTypeActionSet(eventTypeId)
+)
+
 
 
 export const getEventTypeActionSet = (eventTypeId) => ({
@@ -32,5 +32,3 @@ export const getEventTypeActionSet = (eventTypeId) => ({
         failureReason
     })
 })
-
-export default eventTypeActions

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -87,21 +87,22 @@ export const getIncidentsByTicketIdActionSet = (ticketId) => ({
 
 
 export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) =>
-(dispatch) => canFetchByIncidentId(incident)
-            ? incidentNeedsRefresh(incident, ticket, ticketSystem)
+(dispatch) => basicIncidentInfoLoaded(incident)
+            ? fullIncidentInfoLoaded(incident, ticket, ticketSystem, preferences)
                 ? dispatch(fetchIncident(incident.id))
                 : null //No refresh needed
             : ticketId
                 ? dispatch(fetchIncidentsByTicketId(ticketId))
                 : dispatch(fetchIncidents())
 
-const canFetchByIncidentId = (incident) =>  incident&& incident.id
-const incidentNeedsRefresh = (incident, ticket, ticketSystem) => !incident.IsFetching
-|| !ticket
-|| !ticketSystem
-|| !ticket.lastRefresh
-|| ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds'))
+const basicIncidentInfoLoaded = (incident) =>  incident && incident.id
+const fullIncidentInfoLoaded = (incident, ticket, ticketSystem, preferences) => !incident.IsFetching
+&& ticketSystem
+&& isTicketInfoRecent(ticket, preferences)
 
+const isTicketInfoRecent = (ticket, preferences) => ticket
+&& ticket.lastRefresh
+&& ticket.lastRefresh.isAfter(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds'))
 
 export const getIncidentsActionSet = ({
     try: () => ({

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -36,7 +36,7 @@ export const fetchIncidents = () => reduxBackedPromise(
 export const postIncident = (ticketId, ticketSystem) => reduxBackedPromise(
     postIncidentFetchArgs(ticketId, ticketSystem),
     createIncidentActionSet(ticketId, ticketSystem),
-    'post'
+    'POST'
 )
 
 

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -89,8 +89,8 @@ export const getIncidentsByTicketIdActionSet = (ticketId) => ({
 export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) =>
 (dispatch) => basicIncidentInfoLoaded(incident)
             ? fullIncidentInfoLoaded(incident, ticket, ticketSystem, preferences)
-                ? dispatch(fetchIncident(incident.id))
-                : null //No refresh needed
+                ? null //No refresh needed
+                : dispatch(fetchIncident(incident.id))
             : ticketId
                 ? dispatch(fetchIncidentsByTicketId(ticketId))
                 : dispatch(fetchIncidents())

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -85,30 +85,27 @@ export const getIncidentsByTicketIdActionSet = (ticketId) => ({
     })
 })
 
-export const ticketNeedsRefresh = (incident, ticket, ticketSystem, preferences) => {
-    return (!incident
-            || !incident.IsFetching
-            || !ticket
-            || !ticketSystem
-            || !ticket.lastRefresh
-            || ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds')))
-}
 
-export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) => (dispatch) => {
+export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) =>
+(dispatch) => {
     if(!incident || !incident.id) {
         if(ticketId) {
             dispatch(fetchIncidentsByTicketId(ticketId))
+            return
         }
-        else {
-            dispatch(fetchIncidents())
-        }
+        dispatch(fetchIncidents())
+        return
     }
-    else
+
+    if( //ticket needs refresh
+        !incident.IsFetching
+        || !ticket
+        || !ticketSystem
+        || !ticket.lastRefresh
+        || ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds')))
     {
-        if(ticketNeedsRefresh(incident, ticket, ticketSystem, preferences))
-        {
-            dispatch(fetchIncident(incident.id))
-        }
+        dispatch(fetchIncident(incident.id))
+        return
     }
 }
 

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -2,6 +2,7 @@ import moment from 'moment'
 import { authenticatedFetch, authenticatedPost } from '../services/authenticatedFetch'
 import { reduxBackedPromise } from './actionHelpers'
 import * as ticketActions from './ticketActions'
+import * as eventActions from './eventActions'
 
 export const REQUEST_INCIDENT = 'REQUEST_INCIDENT'
 export const RECEIVE_INCIDENT = 'RECEIVE_INCIDENT'
@@ -17,33 +18,33 @@ export const REQUEST_INCIDENT_BY_TICKET_ID = 'REQUEST_INCIDENT_BY_TICKET_ID'
 export const FETCH_INCIDENTS_BY_TICKET_ID_SUCCESS = 'FETCH_INCIDENTS_BY_TICKET_ID_SUCCESS'
 export const FETCH_INCIDENTS_BY_TICKET_ID_FAILURE = 'FETCH_INCIDENTS_BY_TICKET_ID_FAILURE'
 
-export const incidentActions = (siaContext, eventActions) => ({
+export const incidentActions = ({
     fetchIncident: incidentId => reduxBackedPromise(
-        authenticatedFetch(siaContext),
+        authenticatedFetch,
         ['incidents/' + incidentId],
-        getIncidentActionSet(incidentId, eventActions)
+        getIncidentActionSet(incidentId)
     ),
 
     fetchIncidentsByTicketId: (ticketId) => reduxBackedPromise(
-        authenticatedFetch(siaContext),
+        authenticatedFetch,
         ['tickets/' + ticketId],
-        getIncidentsByTicketIdActionSet(ticketId, eventActions),
+        getIncidentsByTicketIdActionSet(ticketId),
     ),
 
     fetchIncidents: () => reduxBackedPromise(
-        authenticatedFetch(siaContext),
+        authenticatedFetch,
         ['incidents/'],
-        getIncidentsActionSet(eventActions)
+        getIncidentsActionSet
     ),
 
     postIncident: (ticketId, ticketSystem) => reduxBackedPromise(
-        authenticatedPost(siaContext),
+        authenticatedPost,
         postIncidentFetchArgs(ticketId, ticketSystem),
-        createIncidentActionSet(ticketId, ticketSystem, eventActions)
+        createIncidentActionSet(ticketId, ticketSystem)
     )
 })
 
-export const getIncidentActionSet = (incidentId, eventActions) => ({
+export const getIncidentActionSet = (incidentId) => ({
     try: () => ({
         type: REQUEST_INCIDENT,
         incidentId
@@ -65,7 +66,7 @@ export const getIncidentActionSet = (incidentId, eventActions) => ({
     })
 })
 
-export const getIncidentsByTicketIdActionSet = (ticketId, eventActions) => ({
+export const getIncidentsByTicketIdActionSet = (ticketId) => ({
     try: () => ({
         type: REQUEST_INCIDENT_BY_TICKET_ID,
         ticketId
@@ -115,7 +116,7 @@ export const fetchIncidentIfNeeded = props => (dispatch) => {
     }
 }
 
-export const getIncidentsActionSet = (eventActions) => ({
+export const getIncidentsActionSet = ({
     try: () => ({
         type: REQUEST_INCIDENTS
     }),
@@ -136,7 +137,7 @@ export const getIncidentsActionSet = (eventActions) => ({
     })
 })
 
-export const createIncidentActionSet = (ticketId, ticketSystem, eventActions) => ({
+export const createIncidentActionSet = (ticketId, ticketSystem) => ({
     try: () => ({
         type: TRY_CREATE_INCIDENT,
         ticketId,

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -1,5 +1,4 @@
 import moment from 'moment'
-import { authenticatedFetch, authenticatedPost } from '../services/authenticatedFetch'
 import { reduxBackedPromise } from './actionHelpers'
 import * as ticketActions from './ticketActions'
 import * as eventActions from './eventActions'
@@ -20,27 +19,24 @@ export const FETCH_INCIDENTS_BY_TICKET_ID_FAILURE = 'FETCH_INCIDENTS_BY_TICKET_I
 
 
 export const fetchIncident = incidentId => reduxBackedPromise(
-    authenticatedFetch,
     ['incidents/' + incidentId],
     getIncidentActionSet(incidentId)
 )
 
 export const fetchIncidentsByTicketId = (ticketId) => reduxBackedPromise(
-    authenticatedFetch,
     ['tickets/' + ticketId],
     getIncidentsByTicketIdActionSet(ticketId),
 )
 
 export const fetchIncidents = () => reduxBackedPromise(
-    authenticatedFetch,
     ['incidents/'],
     getIncidentsActionSet
 )
 
 export const postIncident = (ticketId, ticketSystem) => reduxBackedPromise(
-    authenticatedPost,
     postIncidentFetchArgs(ticketId, ticketSystem),
-    createIncidentActionSet(ticketId, ticketSystem)
+    createIncidentActionSet(ticketId, ticketSystem),
+    'post'
 )
 
 

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -18,31 +18,31 @@ export const REQUEST_INCIDENT_BY_TICKET_ID = 'REQUEST_INCIDENT_BY_TICKET_ID'
 export const FETCH_INCIDENTS_BY_TICKET_ID_SUCCESS = 'FETCH_INCIDENTS_BY_TICKET_ID_SUCCESS'
 export const FETCH_INCIDENTS_BY_TICKET_ID_FAILURE = 'FETCH_INCIDENTS_BY_TICKET_ID_FAILURE'
 
-export const incidentActions = ({
-    fetchIncident: incidentId => reduxBackedPromise(
-        authenticatedFetch,
-        ['incidents/' + incidentId],
-        getIncidentActionSet(incidentId)
-    ),
 
-    fetchIncidentsByTicketId: (ticketId) => reduxBackedPromise(
-        authenticatedFetch,
-        ['tickets/' + ticketId],
-        getIncidentsByTicketIdActionSet(ticketId),
-    ),
+export const fetchIncident = incidentId => reduxBackedPromise(
+    authenticatedFetch,
+    ['incidents/' + incidentId],
+    getIncidentActionSet(incidentId)
+)
 
-    fetchIncidents: () => reduxBackedPromise(
-        authenticatedFetch,
-        ['incidents/'],
-        getIncidentsActionSet
-    ),
+export const fetchIncidentsByTicketId = (ticketId) => reduxBackedPromise(
+    authenticatedFetch,
+    ['tickets/' + ticketId],
+    getIncidentsByTicketIdActionSet(ticketId),
+)
 
-    postIncident: (ticketId, ticketSystem) => reduxBackedPromise(
-        authenticatedPost,
-        postIncidentFetchArgs(ticketId, ticketSystem),
-        createIncidentActionSet(ticketId, ticketSystem)
-    )
-})
+export const fetchIncidents = () => reduxBackedPromise(
+    authenticatedFetch,
+    ['incidents/'],
+    getIncidentsActionSet
+)
+
+export const postIncident = (ticketId, ticketSystem) => reduxBackedPromise(
+    authenticatedPost,
+    postIncidentFetchArgs(ticketId, ticketSystem),
+    createIncidentActionSet(ticketId, ticketSystem)
+)
+
 
 export const getIncidentActionSet = (incidentId) => ({
     try: () => ({
@@ -89,7 +89,7 @@ export const getIncidentsByTicketIdActionSet = (ticketId) => ({
     })
 })
 
-export const ticketNeedsRefresh = ({incident, ticket, ticketSystem, preferences}) => {
+export const ticketNeedsRefresh = (incident, ticket, ticketSystem, preferences) => {
     return (!incident
             || !incident.IsFetching
             || !ticket
@@ -98,20 +98,21 @@ export const ticketNeedsRefresh = ({incident, ticket, ticketSystem, preferences}
             || ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds')))
 }
 
-export const fetchIncidentIfNeeded = props => (dispatch) => {
-    if(!props.incident || !props.incident.id) {
-        if(props.ticketId) {
-            dispatch(props.actions.incident.fetchIncidentsByTicketId(props.ticketId))
+export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) => (dispatch) => {
+    if(!incident || !incident.id) {
+        if(ticketId) {
+            debugger
+            dispatch(fetchIncidentsByTicketId(ticketId))
         }
         else {
-            dispatch(props.actions.incident.fetchIncidents())
+            dispatch(fetchIncidents())
         }
     }
     else
     {
-        if(ticketNeedsRefresh(props))
+        if(ticketNeedsRefresh(incident, ticket, ticketSystem, preferences))
         {
-            dispatch(props.actions.incident.fetchIncident(props.incident.id))
+            dispatch(fetchIncident(incident.id))
         }
     }
 }
@@ -179,5 +180,3 @@ export const duplicateIncident = (ticketId) => (dispatch) => {
     dispatch(createIncidentActionSet(ticketId, {}).fail({ message: 'An incident already exists for this ticket'}))
     dispatch(ticketActions.updateIncidentQuery(ticketId))
 }
-
-export default incidentActions

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -87,20 +87,21 @@ export const getIncidentsByTicketIdActionSet = (ticketId) => ({
 
 
 export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) =>
-(dispatch) => incident
-        && incident.id //Can we fetch by ID?
-        ? (
-            !incident.IsFetching
-            || !ticket
-            || !ticketSystem
-            || !ticket.lastRefresh
-            || ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds'))
-        ) //Do we have everything we need?
-            ? dispatch(fetchIncident(incident.id))
-            : null //we have everything we need
-        : ticketId
-            ? dispatch(fetchIncidentsByTicketId(ticketId))
-            : dispatch(fetchIncidents())
+(dispatch) => canFetchByIncidentId(incident)
+            ? incidentNeedsRefresh(incident, ticket, ticketSystem)
+                ? dispatch(fetchIncident(incident.id))
+                : null //No refresh needed
+            : ticketId
+                ? dispatch(fetchIncidentsByTicketId(ticketId))
+                : dispatch(fetchIncidents())
+
+const canFetchByIncidentId = (incident) =>  incident&& incident.id
+const incidentNeedsRefresh = (incident, ticket, ticketSystem) => !incident.IsFetching
+|| !ticket
+|| !ticketSystem
+|| !ticket.lastRefresh
+|| ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds'))
+
 
 export const getIncidentsActionSet = ({
     try: () => ({

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -87,27 +87,20 @@ export const getIncidentsByTicketIdActionSet = (ticketId) => ({
 
 
 export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) =>
-(dispatch) => {
-    if(!incident || !incident.id) {
-        if(ticketId) {
-            dispatch(fetchIncidentsByTicketId(ticketId))
-            return
-        }
-        dispatch(fetchIncidents())
-        return
-    }
-
-    if( //ticket needs refresh
-        !incident.IsFetching
-        || !ticket
-        || !ticketSystem
-        || !ticket.lastRefresh
-        || ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds')))
-    {
-        dispatch(fetchIncident(incident.id))
-        return
-    }
-}
+(dispatch) => incident
+        && incident.id //Can we fetch by ID?
+        ? (
+            !incident.IsFetching
+            || !ticket
+            || !ticketSystem
+            || !ticket.lastRefresh
+            || ticket.lastRefresh.isBefore(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds'))
+        ) //Do we have everything we need?
+            ? dispatch(fetchIncident(incident.id))
+            : null //we have everything we need
+        : ticketId
+            ? dispatch(fetchIncidentsByTicketId(ticketId))
+            : dispatch(fetchIncidents())
 
 export const getIncidentsActionSet = ({
     try: () => ({

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -101,7 +101,6 @@ export const ticketNeedsRefresh = (incident, ticket, ticketSystem, preferences) 
 export const fetchIncidentIfNeeded = (incident, ticketId, ticket, ticketSystem, preferences) => (dispatch) => {
     if(!incident || !incident.id) {
         if(ticketId) {
-            debugger
             dispatch(fetchIncidentsByTicketId(ticketId))
         }
         else {

--- a/src/components/Auth/EnsureLoggedIn.js
+++ b/src/components/Auth/EnsureLoggedIn.js
@@ -3,21 +3,20 @@ import { connect } from 'react-redux'
 import Login from './Login'
 import LoginError from './LoginError'
 
-export const EnsureLoggedInContainer = ({error, isLoggedIn, ADAL, children}) => {
+export const EnsureLoggedInContainer = ({error, isLoggedIn, children}) => {
   if (error) {
     return <LoginError/>
   }
   if (isLoggedIn) {
     return children
   }
-  return <Login ADAL={ADAL}/>
+  return <Login/>
 }
 
-export const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state) => {
   return {
     isLoggedIn: state.auth.isLoggedIn,
-    error: state.auth.error,
-    ADAL: ownProps.ADAL
+    error: state.auth.error
   }
 }
 

--- a/src/components/Auth/Login.js
+++ b/src/components/Auth/Login.js
@@ -33,7 +33,7 @@ export const LoginComponentDidMount = ({
 
 export const mapStateToProps = (state) => {
     return {
-        ...state.auth,
+        ...state.auth
     }
 }
 

--- a/src/components/Auth/Login.js
+++ b/src/components/Auth/Login.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { startLogin } from '../../actions/authActions'
+import { login } from '../../services/authNService'
 
 export class Login extends React.Component {
     constructor() {
@@ -9,28 +9,31 @@ export class Login extends React.Component {
     
     componentDidMount() {
         //exported separately for testing
-        this.props.LoginComponentDidMount(this.props)
+        LoginComponentDidMount(this.props)
     }
 
     render() {
-        const { dispatch, StartLogin } = this.props
+        const { dispatch } = this.props
         return (
-                <button id="SignIn" onClick={() => dispatch(StartLogin)}>Sign In</button>
+                <button id="SignIn" onClick={() => dispatch(login)}>Sign In</button>
         )
     }
 }
 
-export const LoginComponentDidMount = StartLogin => ({isLoggedIn, loginInProgress, signInAutomatically, dispatch}) => {
+export const LoginComponentDidMount = ({
+    isLoggedIn,
+    loginInProgress,
+    signInAutomatically,
+    dispatch
+}) => {
     if(!isLoggedIn && !loginInProgress && signInAutomatically) {
-        dispatch(StartLogin)
+        dispatch(login)
     }
 }
 
 export const mapStateToProps = (state) => {
     return {
         ...state.auth,
-        LoginComponentDidMount: LoginComponentDidMount(startLogin),
-        StartLogin: startLogin
     }
 }
 

--- a/src/components/Auth/Login.js
+++ b/src/components/Auth/Login.js
@@ -9,27 +9,28 @@ export class Login extends React.Component {
     
     componentDidMount() {
         //exported separately for testing
-        LoginComponentDidMount(this.props)
+        this.props.LoginComponentDidMount(this.props)
     }
 
     render() {
-        const { ADAL, dispatch } = this.props
+        const { dispatch, StartLogin } = this.props
         return (
-                <button id="SignIn" onClick={() => dispatch(startLogin(ADAL))}>Sign In</button>
+                <button id="SignIn" onClick={() => dispatch(StartLogin)}>Sign In</button>
         )
     }
 }
 
-export const LoginComponentDidMount = ({isLoggedIn, loginInProgress, signInAutomatically, ADAL, dispatch}) => {
+export const LoginComponentDidMount = StartLogin => ({isLoggedIn, loginInProgress, signInAutomatically, dispatch}) => {
     if(!isLoggedIn && !loginInProgress && signInAutomatically) {
-        dispatch(startLogin(ADAL))
+        dispatch(StartLogin)
     }
 }
 
-export const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state) => {
     return {
         ...state.auth,
-        ADAL: ownProps.ADAL
+        LoginComponentDidMount: LoginComponentDidMount(startLogin),
+        StartLogin: startLogin
     }
 }
 

--- a/src/components/Debug.js
+++ b/src/components/Debug.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import FlatButtonStyled from './elements/FlatButtonStyled'
+import GetAuthContext from '../services/msalService'
 
-export const Debug = ({authContext}) => {
+export const Debug = () => {
     return (<div>
                 <FlatButtonStyled
                     label='Clear Auth Cache'
-                    onTouchTap={() => authContext.clearCache()}
+                    onTouchTap={() => GetAuthContext().clearCache()}
                 />
             </div>)
 }

--- a/src/components/Debug.js
+++ b/src/components/Debug.js
@@ -1,12 +1,12 @@
 import React from 'react'
 import FlatButtonStyled from './elements/FlatButtonStyled'
-import GetAuthContext from '../services/msalService'
+import { clearCache } from '../services/authNService'
 
 export const Debug = () => {
     return (<div>
                 <FlatButtonStyled
                     label='Clear Auth Cache'
-                    onTouchTap={() => GetAuthContext().clearCache()}
+                    onTouchTap={() => clearCache()}
                 />
             </div>)
 }

--- a/src/components/Engagements.js
+++ b/src/components/Engagements.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import * as engagementActions from '../actions/engagementActions'
 import IconButtonStyled from './elements/IconButtonStyled'
 import PeopleIcon from 'material-ui/svg-icons/social/people'
 import AddCircleOutlineIcon from 'material-ui/svg-icons/content/add-circle-outline'
@@ -16,7 +17,7 @@ export const mapStateToPropsEngagements = (state, ownProps) => {
     }
 }
 
-export const Engagements = ({dispatch, incidentId, engagements, user, engagementActions}) => {
+export const Engagements = ({dispatch, incidentId, engagements, user}) => {
     return (
         <div>
             <span>
@@ -31,16 +32,15 @@ export const Engagements = ({dispatch, incidentId, engagements, user, engagement
                             key={'engagement' + engagement.id}
                             engagement={engagement}
                             user={user}
-                            engagementActions={engagementActions}
                         />)
                 }
             </span>
-            <Engage dispatch={dispatch} incidentId={incidentId} user={user} engagementActions={engagementActions}/>
+            <Engage dispatch={dispatch} incidentId={incidentId} user={user}/>
         </div>
     )
 }
 
-export const Engagement = ({dispatch, engagement, user, engagementActions}) => {
+export const Engagement = ({dispatch, engagement, user}) => {
     return (
         <span>
             {engagement.participant ? engagement.participant.alias : 'No Alias Recorded (BUG)'}
@@ -65,7 +65,7 @@ export const mapStateToPropsEngage = (state, ownProps) => {
     }
 }
 
-export const Engage = ({dispatch, incidentId, user, engagementActions}) => {
+export const Engage = ({dispatch, incidentId, user}) => {
     return (
         <IconButtonStyled
             tooltip='Engage'

--- a/src/components/Incident/CompareIncidents.js
+++ b/src/components/Incident/CompareIncidents.js
@@ -1,20 +1,16 @@
 import { CollapsibleGridSet } from '../elements/CollapsibleGrid'
-import { IncidentSummary, IncidentProgress, IncidentEvents, IncidentSummaryName, IncidentProgressName, IncidentEventsName} from './DisplayIncident'
+import { IncidentSummary, IncidentEvents, IncidentSummaryName, IncidentEventsName} from './DisplayIncident'
 
-export const CompareIncidents = (engagementActions, eventTypeActions, firstIncident, firstTicket, firstTicketSystem, secondIncident, secondTicket, secondTicketSystem, expandSection, dispatch) => {
+export const CompareIncidents = (firstIncident, firstTicket, firstTicketSystem, secondIncident, secondTicket, secondTicketSystem, expandSection, dispatch) => {
     const ticketIdToIncidentIdMap = [[firstTicket.originId, firstIncident.id], [secondTicket.originId, secondIncident.id]]
     return CollapsibleGridSet('incident-container', 'incident-row', 'incident-col', [
-        IncidentSummary(engagementActions, firstIncident, firstTicket, firstTicketSystem, firstTicket.originId, dispatch),
-        IncidentSummary(engagementActions, secondIncident, secondTicket, secondTicketSystem, secondTicket.originId, dispatch),
-        IncidentProgress(firstTicket.originId, dispatch),
-        IncidentProgress(secondTicket.originId, dispatch),
-        IncidentEvents(ticketIdToIncidentIdMap, dispatch, eventTypeActions)
+        IncidentSummary(firstIncident, firstTicket, firstTicketSystem, firstTicket.originId, dispatch),
+        IncidentSummary(secondIncident, secondTicket, secondTicketSystem, secondTicket.originId, dispatch),
+        IncidentEvents(ticketIdToIncidentIdMap, dispatch)
     ],
     [
         IncidentSummaryName(firstTicket.originId),
         IncidentSummaryName(secondTicket.originId),
-        IncidentProgressName(firstTicket.originId),
-        IncidentProgressName(secondTicket.originId),
         IncidentEventsName()
     ],
     expandSection,

--- a/src/components/Incident/CompareTickets.js
+++ b/src/components/Incident/CompareTickets.js
@@ -16,8 +16,7 @@ class CompareTickets extends Component {
         secondTicket: PropTypes.object,
         secondTicketSystem: PropTypes.object.isRequired,
         dispatch: PropTypes.func.isRequired,
-        preferences: PropTypes.object.isRequired,
-        actions: PropTypes.object.isRequired
+        preferences: PropTypes.object.isRequired
     }
 
     componentDidMount() {
@@ -34,27 +33,26 @@ class CompareTickets extends Component {
             secondTicket,
             secondTicketSystem,
             dispatch,
-            actions,
             expandSection
         } = this.props
 
         if(firstIncident && firstIncident.error)
         {
-            return ErrorLoadingIncident(actions.incident, firstIncident)
+            return ErrorLoadingIncident(firstIncident)
         }
         if(secondIncident && secondIncident.error)
         {
-            return ErrorLoadingIncident(actions.incident, secondIncident)
+            return ErrorLoadingIncident(secondIncident)
         }
         if(!firstIncident
             || firstIncident.IsFetching
             || !secondIncident
             || secondIncident.IsFetching){
-            return CurrentlyLoadingIncident(actions.incident, dispatch)
+            return CurrentlyLoadingIncident(dispatch)
         }
         if(firstIncident.primaryTicket.originId === firstTicket.originId && secondIncident.primaryTicket.originId === secondTicket.originId)
         {
-            return (CompareIncidents(actions.engagement, actions.eventType, firstIncident, firstTicket, firstTicketSystem, secondIncident, secondTicket, secondTicketSystem, expandSection, dispatch))
+            return (CompareIncidents(firstIncident, firstTicket, firstTicketSystem, secondIncident, secondTicket, secondTicketSystem, expandSection, dispatch))
         }
         return (
             <Redirect to={`/tickets/${firstIncident.primaryTicket.originId}/compare/${secondIncident.primaryTicket.originId}`}>
@@ -64,7 +62,7 @@ class CompareTickets extends Component {
     }
 }
 
-const mapStateToProps = (actions) => (state, ownProps) => {
+const mapStateToProps = (state, ownProps) => {
     const { incidents, tickets, expandSection } = state
     const { match } = ownProps
     const firstTicketId = parseInt(match.params.firstTicketId)
@@ -81,12 +79,9 @@ const mapStateToProps = (actions) => (state, ownProps) => {
         secondTicketId,
         secondTicketSystem: tickets.systems[getTicketSystemId(secondTicket)],
         preferences: tickets.preferences,
-        expandSection,
-        actions
+        expandSection
     }
 }
 
-
-const connectedCompareTickets = (actions) => connect(mapStateToProps(actions))(CompareTickets)
-
+const connectedCompareTickets = connect(mapStateToProps)(CompareTickets)
 export default connectedCompareTickets

--- a/src/components/Incident/DisplayIncident.js
+++ b/src/components/Incident/DisplayIncident.js
@@ -11,10 +11,10 @@ import { CollapsibleGridSet } from '../elements/CollapsibleGrid'
 import SyncIcon from 'material-ui/svg-icons/notification/sync'
 import { connect } from 'react-redux'
 
-export const DisplayIncident = ({engagementActions, eventActions, eventTypeActions, incident, ticket, ticketSystem, expandSection, dispatch}) => {
+export const DisplayIncident = ({incident, ticket, ticketSystem, expandSection, dispatch}) => {
     return CollapsibleGridSet('incident-container', 'incident-row', 'incident-col', [
-        IncidentSummary(engagementActions, incident, ticket, ticketSystem, null, dispatch),
-        IncidentEvents([[ticket.originId, incident.id]], dispatch, eventActions, eventTypeActions)
+        IncidentSummary(incident, ticket, ticketSystem, null, dispatch),
+        IncidentEvents([[ticket.originId, incident.id]], dispatch)
     ],
     [
         IncidentSummaryName(),
@@ -35,7 +35,7 @@ export const IncidentEventsName = () => {
     return 'IncidentEvents'
 }
 
-export const IncidentSummary = (engagementActions, incident, ticket, ticketSystem, ticketId, dispatch) => {
+export const IncidentSummary = (incident, ticket, ticketSystem, ticketId, dispatch) => {
     let incidentSummaryArray = [
         [
             [
@@ -81,7 +81,6 @@ export const IncidentSummary = (engagementActions, incident, ticket, ticketSyste
                 incidentId={incident.id}
                 engagements={incident.engagements}
                 dispatch={dispatch}
-                engagementActions={engagementActions}
             />
         ]
     ]
@@ -109,7 +108,7 @@ export const IncidentProgress = (ticketId) => {
     return incidentProgressArray
 }
 
-export const IncidentEvents = (ticketToIncidentIdMap, dispatch, eventActions, eventTypeActions) => {
+export const IncidentEvents = (ticketToIncidentIdMap, dispatch) => {
     let incidentEventsArray = [
         [
             [
@@ -120,8 +119,6 @@ export const IncidentEvents = (ticketToIncidentIdMap, dispatch, eventActions, ev
         [
             <Timeline
                 incidentIds={ExtractIncidentIdsFromMap(ticketToIncidentIdMap)}
-                eventActions={eventActions}
-                eventTypeActions={eventTypeActions}
                 ticketId={ticketToIncidentIdMap[0][0]}
                 incidentId={ticketToIncidentIdMap[0][1]}
             />

--- a/src/components/Incident/IncidentRedirect.js
+++ b/src/components/Incident/IncidentRedirect.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import React, { Component } from 'react'
 import { Redirect } from 'react-router'
+import incidentActions from '../../actions/incidentActions'
 
 class IncidentRedirect  extends Component {
     constructor(props){
@@ -8,7 +9,7 @@ class IncidentRedirect  extends Component {
     }
 
     componentDidMount() {
-        const {ticketId, incidentId, dispatch, incidentActions} = this.props
+        const {ticketId, incidentId, dispatch} = this.props
         if(!ticketId){
             dispatch(incidentActions.fetchIncident(incidentId))
         }
@@ -22,13 +23,12 @@ class IncidentRedirect  extends Component {
     }
 }
 
-const mapStateToProps = (incidentActions) => (state, ownProps) => {
+const mapStateToProps = (state, ownProps) => {
     const incident = state.incidents.map[ownProps.match.params.incidentId]
     return {
         incidentId: ownProps.match.params.incidentId,
-        ticketId: (incident ? (incident.primaryTicket ? incident.primaryTicket.originId : null) : null),
-        incidentActions
+        ticketId: (incident ? (incident.primaryTicket ? incident.primaryTicket.originId : null) : null)
     }
 }
 
-export default (incidentActions) => connect(mapStateToProps(incidentActions))(IncidentRedirect)
+export default connect(mapStateToProps)(IncidentRedirect)

--- a/src/components/Incident/Ticket.js
+++ b/src/components/Incident/Ticket.js
@@ -19,7 +19,8 @@ class Ticket extends Component {
     }
 
     componentDidMount() {
-        this.props.dispatch(incidentActions.fetchIncidentIfNeeded(this.props))
+        const { dispatch, incident, ticketId, ticket, ticketSystem, preferences } = this.props
+        dispatch(incidentActions.fetchIncidentIfNeeded(incident, ticketId, ticket, ticketSystem, preferences))
     }
 
     render() {

--- a/src/components/Popups.js
+++ b/src/components/Popups.js
@@ -3,11 +3,11 @@ import { connect } from 'react-redux'
 import EventDialog from '../components/Timeline/AddEventDialog'
 import { addEventPopupName } from '../components/Incident/EventDialogControl'
 
-export const Popups = ({selectedPopup, eventActions}) => {
+export const Popups = ({selectedPopup}) => {
     let toRender
     switch(selectedPopup) {
         case addEventPopupName:
-            toRender = <EventDialog eventActions={eventActions}/>
+            toRender = <EventDialog/>
             break
         default:
             toRender = <div/>
@@ -16,10 +16,9 @@ export const Popups = ({selectedPopup, eventActions}) => {
     return toRender
 }
 
-export const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state) => {
     return {
-        selectedPopup: state.popup ? state.popup.popupName : null,
-        eventActions: ownProps.eventActions
+        selectedPopup: state.popup ? state.popup.popupName : null
     }
 }
 

--- a/src/components/Search/CreateIncident.js
+++ b/src/components/Search/CreateIncident.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux'
 import { TextField } from 'material-ui'
 import FlatButtonStyled from '../elements/FlatButtonStyled'
 import { updateIncidentCreationInput } from '../../actions/incidentActions'
+
 const onSubmit = (input, ticketSystem, history) => () => {
 
     history.push(/tickets/ + input)
@@ -24,13 +25,12 @@ export const CreateIncident = ({input, ticketSystem, creationError, history, dis
     </div>
 }
 
-export const mapStateToProps = (incidentActions) => (state) => {
+export const mapStateToProps = (state) => {
     return {
         input: state.incidents.creation.input,
         ticketSystem: state.tickets.systems[1],
-        creationError: state.incidents.creation.error ? state.incidents.creation.error.message : '',
-        incidentActions
+        creationError: state.incidents.creation.error ? state.incidents.creation.error.message : ''
     }
 }
 
-export default (incidentActions) => connect(mapStateToProps(incidentActions))(CreateIncident)
+export default connect(mapStateToProps)(CreateIncident)

--- a/src/components/Timeline/AddEvent.js
+++ b/src/components/Timeline/AddEvent.js
@@ -3,9 +3,10 @@ import { connect } from 'react-redux'
 import RaisedButtonStyled from '../../components/elements/RaisedButtonStyled'
 import * as formActions from '../../actions/formActions'
 import * as popupActions from '../../actions/popupActions'
+import * as eventActions from '../../actions/eventActions'
 import { addEventFormName } from '../Incident/EventDialogControl'
 
-const AddEvent = ({ dispatch, incidentIds, selectedIncidentId, eventInput, eventTypeIdInput, updateSelectedIncidentId, updateEventInput, updateEventTypeIdInput, eventActions }) => {
+const AddEvent = ({ dispatch, incidentIds, selectedIncidentId, eventInput, eventTypeIdInput, updateSelectedIncidentId, updateEventInput, updateEventTypeIdInput }) => {
   let incidentIdCounter = 0
   return (
     <div>

--- a/src/components/Timeline/AddEventDialog.js
+++ b/src/components/Timeline/AddEventDialog.js
@@ -11,7 +11,7 @@ const handleUpdateEvent = (dispatch, key) => (value) => event => {
     dispatch(formActions.updateInput(addEventFormName, key, value ? value : event.target.value))
 }
 
-export const addEventDialog = ({dispatch, form, args, eventActions}) => <Dialog
+export const addEventDialog = ({dispatch, form, args}) => <Dialog
         title='Please enter a custom event:'
         actions={addEventDialogOptions(dispatch)}
         open={true}
@@ -27,7 +27,6 @@ export const addEventDialog = ({dispatch, form, args, eventActions}) => <Dialog
             updateEventInput={handleUpdateEvent(dispatch, eventInputKey)}
             updateSelectedIncidentId={handleUpdateEvent(dispatch, selectedIncidentIdKey)}
             updateEventTypeIdInput={handleUpdateEvent(dispatch, eventTypeIdInputKey)}
-            eventActions={eventActions}
         />
     </Dialog>
 
@@ -39,14 +38,12 @@ export const addEventDialogOptions = (dispatch) => [
     />
 ]
 
-export const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state) => {
     return {
         form: state.forms[addEventFormName] ? state.forms[addEventFormName] : {},
-        args: state.popup.args,
-        eventActions: ownProps.eventActions
+        args: state.popup.args
     }
 }
 
-export const connectedAddEventDialog = connect(mapStateToProps)(addEventDialog)
+export default connect(mapStateToProps)(addEventDialog)
 
-export default connectedAddEventDialog

--- a/src/components/Timeline/Event.js
+++ b/src/components/Timeline/Event.js
@@ -14,9 +14,7 @@ export const Event = ({
     incidentId,
     ticketId,
     eventTypeId,
-    eventId,
-    eventActions,
-    eventTypeActions
+    eventId
 }) => {
     return (
     <div>
@@ -25,7 +23,6 @@ export const Event = ({
             eventTypeId={eventTypeId}
             ticketId={ticketId}
             incidentId={incidentId}
-            eventTypeActions={eventTypeActions}
         />
         <Card
             className="incident-card"
@@ -44,7 +41,6 @@ export const Event = ({
                     eventTypeId={eventTypeId}
                     ticketId={ticketId}
                     incidentId={incidentId}
-                    eventActions={eventActions}
                 />
             </CardText>
         </Card>

--- a/src/components/Timeline/Events.js
+++ b/src/components/Timeline/Events.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Event from './Event'
 
-export const Events = (events, eventActions, eventTypeActions, ticketId, incidentId) => {
+export const Events = (events, ticketId, incidentId) => {
   let localKey = 0
   return (
     Array.from(events)
@@ -11,8 +11,6 @@ export const Events = (events, eventActions, eventTypeActions, ticketId, inciden
           incidentId = {incidentId}
           ticketId = {ticketId}
           event = {event}
-          eventActions = {eventActions}
-          eventTypeActions = {eventTypeActions}
         />
     )
   )

--- a/src/components/Timeline/Playbook/Play.js
+++ b/src/components/Timeline/Playbook/Play.js
@@ -3,12 +3,11 @@ import { connect } from 'react-redux'
 import FlatButtonStyled from '../../../components/elements/FlatButtonStyled'
 import { fillTemplate, publishEvent } from '../../../services/playbookService'
 
-
-export const Play = ({incidentId, isUrl, filledTemplate, name, eventActions, dispatch}) => {
+export const Play = ({incidentId, isUrl, filledTemplate, name}) => {
     return isUrl ? <a href={filledTemplate}>Link: {name}</a>
                  : <FlatButtonStyled
                         label={'Publish Event: ' + name}
-                        onTouchTap={publishEvent(incidentId, eventActions, dispatch)(filledTemplate)}
+                        onTouchTap={publishEvent(incidentId, filledTemplate)}
                     />
 }
 

--- a/src/components/Timeline/Playbook/Playbook.js
+++ b/src/components/Timeline/Playbook/Playbook.js
@@ -3,16 +3,13 @@ import { connect } from 'react-redux'
 import Play from './Play'
 import { TestConditionSet } from '../../../services/playbookService'
 
-
 export const Playbook = ({
     eventTypeId,
     eventId,
     incidentId,
     ticketId,
     engagementId,
-    actions,
-    eventActions,
-    eventTypeActions
+    actions
 }) => {
     let localKey = 0
     return  <div>{
@@ -30,8 +27,6 @@ export const Playbook = ({
                             incidentId={incidentId}
                             ticketId={ticketId}
                             engagementId={engagementId}
-                            eventActions={eventActions}
-                            eventTypeActions={eventTypeActions}
                         />
                     </div>)
                 : <div>Fetching action options...</div>

--- a/src/components/Timeline/Timeline.js
+++ b/src/components/Timeline/Timeline.js
@@ -14,11 +14,7 @@ class Timeline extends Component {
   }
 
   componentDidMount() {
-    updatePagination(this.props.dispatch, this.props.incidentIds)
-  }
-
-  componentDidUpdate() {
-    updatePagination(this.props.dispatch, this.props.incidentIds)
+    dispatch(eventActions.pagination.filter(this.props.incidentIds[0].toString()))
   }
 
   render() {
@@ -31,11 +27,6 @@ class Timeline extends Component {
       </div>
     )
   }
-}
-
-const updatePagination = (dispatch, incidentIds) => {
-    dispatch(eventActions.pagination.filter(incidentIds[0].toString()))
-    dispatch(eventActions.pagination.sort('occurred'))
 }
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/components/Timeline/Timeline.js
+++ b/src/components/Timeline/Timeline.js
@@ -15,15 +15,18 @@ class Timeline extends Component {
 
   componentDidMount() {
     updatePagination(this.props.dispatch, this.props.incidentIds)
-    fetchMissingEventTypes(this.props)
+  }
+
+  componentDidUpdate() {
+    updatePagination(this.props.dispatch, this.props.incidentIds)
   }
 
   render() {
-    const { events, dispatch, eventActions, eventTypeActions, ticketId, incidentId, eventTypes } = this.props
+    const { events, dispatch, ticketId, incidentId, eventTypes } = this.props
     return (
       <div>
         <Filter pagination={events} dispatch={dispatch}/>
-        {Events(events.pageList, eventActions, eventTypeActions, ticketId, incidentId, eventTypes)}
+        {Events(events.pageList, ticketId, incidentId, eventTypes)}
         <Footer pagination={events} dispatch={dispatch}/>
       </div>
     )
@@ -33,14 +36,6 @@ class Timeline extends Component {
 const updatePagination = (dispatch, incidentIds) => {
     dispatch(eventActions.pagination.filter(incidentIds[0].toString()))
     dispatch(eventActions.pagination.sort('occurred'))
-}
-
-const fetchMissingEventTypes = (props) => {
-  const eventTypeIds = Object.keys(props.eventTypes)
-  props.events.pageList
-    .map(event => event.eventTypeId)
-    .filter(eventTypeId => !eventTypeIds.includes(eventTypeId))
-    .forEach(missingEventTypeId => props.dispatch(props.eventTypeActions.fetchEventType(missingEventTypeId)))
 }
 
 const mapStateToProps = (state, ownProps) => {

--- a/src/components/Timeline/Timeline.js
+++ b/src/components/Timeline/Timeline.js
@@ -14,7 +14,7 @@ class Timeline extends Component {
   }
 
   componentDidMount() {
-    dispatch(eventActions.pagination.filter(this.props.incidentIds[0].toString()))
+    this.props.dispatch(eventActions.pagination.filter(this.props.incidentIds[0].toString()))
   }
 
   render() {

--- a/src/components/TopNav/NavMenu.js
+++ b/src/components/TopNav/NavMenu.js
@@ -5,7 +5,7 @@ import IconMenu from 'material-ui/IconMenu'
 import { Link } from 'react-router-dom'
 import NavigationMenu from 'material-ui/svg-icons/navigation/menu'
 import IconButton from 'material-ui/IconButton'
-import { onLogoutActions } from '../../actions/authActions'
+import * as auth from '../../services/authNService'
 
 export const mapStateToProps = (state) => {
     return {
@@ -21,7 +21,7 @@ export const NavMenu = ({dispatch, alias}) =>
 >
     <MenuItem primaryText={ alias }/>
     <MenuItem primaryText={<Link to="/" >Incident Search</Link>} />
-    <MenuItem primaryText={<Link to="/" onClick={() => dispatch(onLogoutActions)}>LogOut</Link>} />
+    <MenuItem primaryText={<Link to="/" onClick={() => dispatch(auth.logOut)}>LogOut</Link>} />
     <MenuItem primaryText={<Link to="/debug" >Debug</Link>} />
 </IconMenu>
 

--- a/src/components/TopNav/NavMenu.js
+++ b/src/components/TopNav/NavMenu.js
@@ -13,17 +13,17 @@ export const mapStateToProps = (state) => {
     }
 }
 
-export const NavMenu = ({dispatch, alias}) => {
-        return <IconMenu
-                    iconButtonElement={<IconButton><NavigationMenu /></IconButton>}
-                    anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
-                    targetOrigin={{horizontal: 'left', vertical: 'top'}}
-                >
-                    <MenuItem primaryText={ alias }/>
-                    <MenuItem primaryText={<Link to="/" >Incident Search</Link>} />
-                    <MenuItem primaryText={<Link to="/" onClick={() => onLogoutActions(dispatch)}>LogOut</Link>} />
-                    <MenuItem primaryText={<Link to="/debug" >Debug</Link>} />
-                </IconMenu>
-}
+export const NavMenu = ({dispatch, alias}) =>
+<IconMenu
+    iconButtonElement={<IconButton><NavigationMenu /></IconButton>}
+    anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
+    targetOrigin={{horizontal: 'left', vertical: 'top'}}
+>
+    <MenuItem primaryText={ alias }/>
+    <MenuItem primaryText={<Link to="/" >Incident Search</Link>} />
+    <MenuItem primaryText={<Link to="/" onClick={() => dispatch(onLogoutActions)}>LogOut</Link>} />
+    <MenuItem primaryText={<Link to="/debug" >Debug</Link>} />
+</IconMenu>
+
 
 export default connect(mapStateToProps)(NavMenu)

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,6 @@ import {
   Route
 } from 'react-router-dom'
 import createBrowserHistory from 'history/createBrowserHistory'
-import eventActionInitializer from './actions/eventActions'
-import incidentActionInitializer from './actions/incidentActions'
-import engagementActionInitializer from './actions/engagementActions'
-import eventTypeActionInitializer from './actions/eventTypeActions'
 import CreateIncident from './components/Search/CreateIncident'
 import Ticket from './components/Incident/Ticket'
 import CompareTickets from './components/Incident/CompareTickets'
@@ -27,25 +23,13 @@ import incidentRedirect from './components/Incident/incidentRedirect'
 import TopNav from './components/TopNav/TopNav'
 import Debug from './components/Debug'
 import { ListenForScreenSize } from './actions/styleActions'
-import { authContext, clientId, generateSiaContext } from './services/adalService'
 import establishSignalRConnection from './services/signalRService'
 import Popups from './components/Popups'
 
-const authenticationContext = authContext
-
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
-export const store = createStore(incidentApp(authContext, clientId), composeEnhancers(applyMiddleware(thunk)))
+export const store = createStore(incidentApp(), composeEnhancers(applyMiddleware(thunk)))
 
 establishSignalRConnection(store.dispatch)
-const siaContext = generateSiaContext(authenticationContext, store.dispatch)
-
-const eventActions = eventActionInitializer(siaContext)
-const actions = ({
-  event: eventActions,
-  incident: incidentActionInitializer(siaContext, eventActions),
-  engagement: engagementActionInitializer(siaContext),
-  eventType: eventTypeActionInitializer(siaContext)
-})
 
 ListenForScreenSize(window, store)
 const history = createBrowserHistory()
@@ -56,16 +40,16 @@ class MainComponent extends React.Component {
       <MuiThemeProvider muiTheme={getMuiTheme()}>
         <Provider store={store}>
           <div>
-            <EnsureLoggedInContainer ADAL={siaContext.authContext}>
+            <EnsureLoggedInContainer>
               <Router history={history} >
                 <div>
                   <TopNav />
-                  <Popups eventActions={eventActions} />
-                  <Route exact path="/" component={CreateIncident(actions.incident)} />
-                  <Route exact path="/tickets/:ticketId" component={Ticket(actions)} />
-                  <Route path="/tickets/:firstTicketId/compare/:secondTicketId" component={CompareTickets(actions)} />
-                  <Route path="/incidents/:incidentId" component={incidentRedirect(actions.incident)} />
-                  <Route path="/debug" render={() => <Debug authContext={siaContext.authContext} dispatch={store.dispatch}/>}/>
+                  <Popups />
+                  <Route exact path="/" component={CreateIncident} />
+                  <Route exact path="/tickets/:ticketId" component={Ticket} />
+                  <Route path="/tickets/:firstTicketId/compare/:secondTicketId" component={CompareTickets} />
+                  <Route path="/incidents/:incidentId" component={incidentRedirect} />
+                  <Route path="/debug" render={() => <Debug />}/>
                 </div>
               </Router>
             </EnsureLoggedInContainer>

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -20,7 +20,8 @@ const getDefaultState = () => {
         signInAutomatically: true,
         userTeam: 'none',
         userRole: 'Crisis Manager',
-        userAlias: (user && user.userName) ? extractAliasFromUserName(user.userName) : null
+        userAlias: (user && user.displayableId) ? extractAliasFromUserName(user.displayableId) : null,
+        userUniqueId: user ? user.userIdentifier : null
     }
 }
 
@@ -39,7 +40,8 @@ const authReducer = (state = getDefaultState(), action) => {
                 error: null,
                 loginInProgress: false,
                 signInAutomatically: true,
-                userAlias: extractAliasFromUserName(action.user.userName)
+                userAlias: (action.user && action.user.displayableId) ? extractAliasFromUserName(action.user.displayableId) : null,
+                userUniqueId: action.user ? action.user.userIdentifier : null
             }
         case USER_LOGGED_OUT:
             return {

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -2,14 +2,15 @@ import { USER_LOGGED_IN, USER_LOGGED_OUT, USER_LOGIN_ERROR, LOGIN_IN_PROGRESS } 
 import * as authNService from '../services/authNService'
 
 const getDefaultState = () => {
-    return {
+    const defaultState = {
         isLoggedIn: authNService.isLoggedIn(),
-        loginInProgress: false,
+        loginInProgress: authNService.loginInProgress(),
         signInAutomatically: true,
         userTeam: 'none',
         userRole: 'Crisis Manager',
         userAlias: authNService.getUserAlias()
     }
+    return defaultState
 }
 
 const authReducer = (state = getDefaultState(), action) => {

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -1,27 +1,14 @@
 import { USER_LOGGED_IN, USER_LOGGED_OUT, USER_LOGIN_ERROR, LOGIN_IN_PROGRESS } from '../actions/authActions.js'
-import { getAuthContext } from '../services/msalService'
-
-const extractAliasFromUserName = (userName) => {
-    return userName.slice(0, userName.indexOf('@'))
-}
+import * as authNService from '../services/authNService'
 
 const getDefaultState = () => {
-    var isLoggedIn
-    const authContext = getAuthContext()
-    authContext.acquireTokenSilent()
-        .then(
-            () => isLoggedIn = true,
-            () => isLoggedIn = false
-        )
-    const user = authContext.getUser()
     return {
-        isLoggedIn,
+        isLoggedIn: authNService.isLoggedIn(),
         loginInProgress: false,
         signInAutomatically: true,
         userTeam: 'none',
         userRole: 'Crisis Manager',
-        userAlias: (user && user.displayableId) ? extractAliasFromUserName(user.displayableId) : null,
-        userUniqueId: user ? user.userIdentifier : null
+        userAlias: authNService.getUserAlias()
     }
 }
 
@@ -40,8 +27,7 @@ const authReducer = (state = getDefaultState(), action) => {
                 error: null,
                 loginInProgress: false,
                 signInAutomatically: true,
-                userAlias: (action.user && action.user.displayableId) ? extractAliasFromUserName(action.user.displayableId) : null,
-                userUniqueId: action.user ? action.user.userIdentifier : null
+                userAlias: authNService.getUserAlias(action.user)
             }
         case USER_LOGGED_OUT:
             return {

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -1,14 +1,21 @@
 import { USER_LOGGED_IN, USER_LOGGED_OUT, USER_LOGIN_ERROR, LOGIN_IN_PROGRESS } from '../actions/authActions.js'
+import { getAuthContext } from '../services/msalService'
 
 const extractAliasFromUserName = (userName) => {
     return userName.slice(0, userName.indexOf('@'))
 }
 
-const getDefaultState = (authContext, clientId) => {
-    const token = authContext.getCachedToken(clientId)
-    const user = authContext.getCachedUser()
+const getDefaultState = () => {
+    var isLoggedIn
+    const authContext = getAuthContext()
+    authContext.acquireTokenSilent()
+        .then(
+            () => isLoggedIn = true,
+            () => isLoggedIn = false
+        )
+    const user = authContext.getUser()
     return {
-        isLoggedIn: (!!token),
+        isLoggedIn,
         loginInProgress: false,
         signInAutomatically: true,
         userTeam: 'none',
@@ -17,7 +24,7 @@ const getDefaultState = (authContext, clientId) => {
     }
 }
 
-const authReducer = (authContext, clientId) => (state = getDefaultState(authContext, clientId), action) => {
+const authReducer = (state = getDefaultState(), action) => {
     switch (action.type) {
         case LOGIN_IN_PROGRESS:
             return {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -10,9 +10,9 @@ import popup from './popupReducer'
 import forms from './formReducer'
 import eventTypes from './eventTypeReducer'
 
-const rootReducer = (authContext, clientId) => combineReducers({
+const rootReducer = () => combineReducers({
     incidents,
-    auth: auth(authContext, clientId),
+    auth,
     tickets,
     engagements,
     events,

--- a/src/services/adalService.js
+++ b/src/services/adalService.js
@@ -1,3 +1,4 @@
+
 import AuthenticationContext from 'adal-angular'
 import * as authActions from '../actions/authActions'
 
@@ -37,7 +38,7 @@ export const login = (dispatch) => {
 
 export const logOut = (dispatch) => {
   getAuthContext().logOut()
-  dispatch(userLoggedOut())
+  dispatch(authActions.userLoggedOut())
 }
 
 export const clearCache = () => {

--- a/src/services/adalService.js
+++ b/src/services/adalService.js
@@ -4,7 +4,10 @@ import * as authActions from '../actions/authActions'
 // eslint-disable-next-line no-undef
 export const clientId = CLIENT_ID //From config
 
-export const authContext = new AuthenticationContext({
+export const authVersion = 'adal'
+
+
+export const getAuthContext = () => new AuthenticationContext({
       instance: 'https://login.microsoftonline.com/',
       // eslint-disable-next-line no-undef
       tenant: AAD_TENANT, //From config
@@ -15,22 +18,61 @@ export const authContext = new AuthenticationContext({
       popUp: true
   })
 
-export const generateSiaContext = (authContext, dispatch) => {
-  const context = ({
-    authContext,
-    dispatch
-  })
-
-  context.authContext.callback = userSignedIn(context)
-  return context
+export const login = (dispatch) => {
+  if(typeof window !== 'undefined' && !!window)
+  {
+    const context = getAuthContext()
+    context.callback = (err) => {
+      err
+        ? dispatch(authActions.userLoginError(err))
+        : dispatch(authActions.userLoggedIn(getAuthContext().getCachedUser()))
+    }
+    context.login()
+  }
+  else
+  {
+      dispatch(authActions.userLoginError('Window is undefined, so ADAL cannot function!'))
+  }
 }
 
-export const userSignedIn =
-  (siaContext) =>
-  (err) => {
-    if (err) {
-      siaContext.dispatch(authActions.userLoginError(err))
-      return
-    }
-    setTimeout(siaContext.dispatch, null, authActions.onLoginActions(siaContext))
+export const logOut = (dispatch) => {
+  getAuthContext().logOut()
+  dispatch(userLoggedOut())
+}
+
+export const clearCache = () => {
+  getAuthContext().clearCache()
+}
+
+export const isLoggedIn = () => {
+  const token = getAuthContext().getCachedToken(clientId)
+  return !!token
+}
+
+export const getUserAlias = (passedInUser) => {
+  const user = passedInUser
+      ? passedInUser
+      : getAuthContext().getUser()
+  return (user && user.userName)
+      ? extractAliasFromUserName(user.userName)
+      : null
+}
+
+const extractAliasFromUserName = (userName) => {
+  return userName.slice(0, userName.indexOf('@'))
+}
+
+export const getToken = () => tokenPromise()
+
+
+const tokenPromise = () => new Promise(
+  (resolve, reject) => {
+    getAuthContext().acquireToken(clientId, callbackBridge(resolve, reject))
   }
+)
+
+const callbackBridge = (resolve, reject) => (errDesc, token) => errDesc
+  ? reject(errDesc)
+  : resolve(token)
+
+  

--- a/src/services/adalService.js
+++ b/src/services/adalService.js
@@ -26,7 +26,6 @@ export const getAuthContext = (dispatch) => {
   if(dispatch)
   {
     context.callback = (err) => {
-      console.log('result from callback: ' + err)
       err
         ? dispatch(authActions.userLoginError(err))
         : dispatch(authActions.userLoggedIn(context.getCachedUser()))

--- a/src/services/adalShim.js
+++ b/src/services/adalShim.js
@@ -1,0 +1,35 @@
+/*
+Why does this exist?
+
+Purely because ADAL assumes a
+window object is available
+at Require() time. When we
+test on PhantomJS, no such
+window is available, so this
+module is designed to be Require()d
+ahead of ADAL to provide it
+with a window object to set
+logging on so that no exception
+is thrown before tests are run.
+
+There is a code fix available
+on the ADAL side, but they
+have not yet released it to NPM,
+so here we are.
+
+Remove this file as soon as
+ADAL itself is fixed.
+*/
+
+let shimStatement
+if(typeof(window) !== 'undefined')
+{
+    shimStatement = ''
+}
+else
+{
+    shimStatement = 'var window = {location:{href:"http://localhost"}};'
+}
+
+var geval = eval //force eval to use global scope
+geval(shimStatement)

--- a/src/services/authNService.js
+++ b/src/services/authNService.js
@@ -1,0 +1,69 @@
+import * as msalService from './msalService'
+import * as adalService from './adalService'
+import * as authActions from '../actions/authActions'
+// eslint-disable-next-line no-undef
+const authVersion = AUTH_VERSION
+
+
+
+
+export const login = (dispatch) => {
+    dispatch(authActions.loginInProgress())
+    switch(authVersion)
+    {
+        case msalService.authVersion:
+            dispatch(msalService.login)
+        default:
+            dispatch(adalService.login)
+    }
+}
+
+export const logOut = (dispatch) => {
+    switch(authVersion)
+    {
+        case msalService.authVersion:
+            dispatch(msalService.logOut)
+        default:
+            dispatch(adalService.logOut)
+    }
+}
+
+export const clearCache = () => {
+    switch(authVersion)
+    {
+        case msalService.authVersion:
+            msalService.clearCache()
+        default:
+            adalService.clearCache()
+    }
+}
+
+export const isLoggedIn = () => {
+    switch(authVersion)
+    {
+        case msalService.authVersion:
+            return msalService.isLoggedIn()
+        default:
+            return adalService.isLoggedIn()
+    }
+}
+
+export const getUserAlias = (user) => {
+    switch(authVersion)
+    {
+        case msalService.authVersion:
+            return msalService.getUserAlias(user)
+        default:
+            return adalService.getUserAlias(user)
+    }
+}
+
+export const getToken = () => {
+    switch(authVersion)
+    {
+        case msalService.authVersion:
+            return msalService.getToken()
+        default:
+            return adalService.getToken()
+    }
+}

--- a/src/services/authNService.js
+++ b/src/services/authNService.js
@@ -3,8 +3,9 @@ import * as unused from './adalShim' //see file for more info
 import * as msalService from './msalService'
 import * as adalService from './adalService'
 import * as authActions from '../actions/authActions'
-// eslint-disable-next-line no-undef
-const authVersion = AUTH_VERSION
+import config from 'config'
+
+const authVersion = config.authVersion
 
 const testAuthVersion = 'TEST'
 const testLoginAction = ({type:'TEST_LOGIN'})

--- a/src/services/authNService.js
+++ b/src/services/authNService.js
@@ -1,18 +1,27 @@
+// eslint-disable-next-line no-unused-vars
+import * as unused from './adalShim' //see file for more info
 import * as msalService from './msalService'
 import * as adalService from './adalService'
 import * as authActions from '../actions/authActions'
 // eslint-disable-next-line no-undef
 const authVersion = AUTH_VERSION
 
-
-
+const testAuthVersion = 'TEST'
+const testLoginAction = ({type:'TEST_LOGIN'})
+const testLogOutAction = ({type:'TEST_LOGOUT'})
+const testAlias = 'Test@test.test'
+const testToken = 'testToken'
 
 export const login = (dispatch) => {
     dispatch(authActions.loginInProgress())
     switch(authVersion)
     {
+        case testAuthVersion:
+            dispatch(testLoginAction)
+            break
         case msalService.authVersion:
             dispatch(msalService.login)
+            break
         default:
             dispatch(adalService.login)
     }
@@ -21,8 +30,12 @@ export const login = (dispatch) => {
 export const logOut = (dispatch) => {
     switch(authVersion)
     {
+        case testAuthVersion:
+            dispatch(testLogOutAction)
+            break
         case msalService.authVersion:
             dispatch(msalService.logOut)
+            break
         default:
             dispatch(adalService.logOut)
     }
@@ -33,6 +46,9 @@ export const clearCache = () => {
     {
         case msalService.authVersion:
             msalService.clearCache()
+            break
+        case testAuthVersion:
+            break
         default:
             adalService.clearCache()
     }
@@ -41,6 +57,8 @@ export const clearCache = () => {
 export const isLoggedIn = () => {
     switch(authVersion)
     {
+        case testAuthVersion:
+            return false
         case msalService.authVersion:
             return msalService.isLoggedIn()
         default:
@@ -51,6 +69,8 @@ export const isLoggedIn = () => {
 export const getUserAlias = (user) => {
     switch(authVersion)
     {
+        case testAuthVersion:
+            return testAlias
         case msalService.authVersion:
             return msalService.getUserAlias(user)
         default:
@@ -58,11 +78,13 @@ export const getUserAlias = (user) => {
     }
 }
 
-export const getToken = () => {
+export const getToken = (scopes) => {
     switch(authVersion)
     {
+        case testAuthVersion:
+            return testToken
         case msalService.authVersion:
-            return msalService.getToken()
+            return msalService.getToken(scopes)
         default:
             return adalService.getToken()
     }

--- a/src/services/authNService.js
+++ b/src/services/authNService.js
@@ -90,3 +90,15 @@ export const getToken = (scopes) => {
             return adalService.getToken()
     }
 }
+
+export const loginInProgress = () => {
+    switch(authVersion)
+    {
+        case testAuthVersion:
+            return false
+        case msalService.authVersion:
+            return msalService.loginInProgress()
+        default:
+            return adalService.loginInProgress()
+    }
+}

--- a/src/services/authenticatedFetch.js
+++ b/src/services/authenticatedFetch.js
@@ -1,7 +1,6 @@
 import { rawHttpResponse, jsonResult } from '../actions/debugActions'
 import PromiseRetry from 'promise-retry'
 import { getToken } from './authNService'
-import * as authActions from '../actions/authActions'
 import config from 'config'
 
 export const clientId = config.clientId

--- a/src/services/authenticatedFetch.js
+++ b/src/services/authenticatedFetch.js
@@ -41,7 +41,7 @@ const tryFetch = (dispatch, relativeUrl, init, returnJson = true, baseUrl = defa
         }, err => retry(`Error during fetch: ${err} (retry ${number})`))
 }
 
-const tryGetToken = (retry, number) => getToken()
+const tryGetToken = (retry, number) => getToken(defaultScopes)
     .then(token => token)
     .catch(err => retry(`Error when attempting to retrieve token: ${err} (retry ${number})`))
 

--- a/src/services/authenticatedFetch.js
+++ b/src/services/authenticatedFetch.js
@@ -17,7 +17,7 @@ const defaultOptions = {
     // eslint-disable-next-line no-undef
     maxTimeout: RETRY_MAX_TIMEOUT
 }
-const defaultScopes = [CLIENT_ID]
+const defaultScopes = [clientId]
 
 const tryFetch = (dispatch, relativeUrl, init, returnJson = true, baseUrl = defaultBasePath) => (retry, number) => {
     return fetch(baseUrl + relativeUrl, init)

--- a/src/services/authenticatedFetch.js
+++ b/src/services/authenticatedFetch.js
@@ -17,6 +17,7 @@ const defaultOptions = {
     // eslint-disable-next-line no-undef
     maxTimeout: RETRY_MAX_TIMEOUT
 }
+const defaultScopes = [CLIENT_ID]
 
 const tryFetch = (dispatch, relativeUrl, init, returnJson = true, baseUrl = defaultBasePath) => (retry, number) => {
     return fetch(baseUrl + relativeUrl, init)
@@ -41,11 +42,9 @@ const tryFetch = (dispatch, relativeUrl, init, returnJson = true, baseUrl = defa
 }
 
 const tryGetToken = (authContext) => (retry, number) =>
-authContext.acquireTokenSilent()
+authContext.acquireTokenSilent(defaultScopes)
     .then(
-        token => token,
-        () => authContext.acquireTokenPopup()
-            .then(token => token)
+        token => token
     )
     .catch(err => retry(`Error during fetch: ${err} (retry ${number})`))
 

--- a/src/services/authenticatedFetch.js
+++ b/src/services/authenticatedFetch.js
@@ -1,6 +1,6 @@
 import { rawHttpResponse, jsonResult } from '../actions/debugActions'
 import PromiseRetry from 'promise-retry'
-import GetAuthContext from './msalService'
+import { getToken } from './authNService'
 
 // eslint-disable-next-line no-undef
 export const clientId = CLIENT_ID //From config
@@ -41,18 +41,14 @@ const tryFetch = (dispatch, relativeUrl, init, returnJson = true, baseUrl = defa
         }, err => retry(`Error during fetch: ${err} (retry ${number})`))
 }
 
-const tryGetToken = (authContext) => (retry, number) =>
-authContext.acquireTokenSilent(defaultScopes)
-    .then(
-        token => token
-    )
-    .catch(err => retry(`Error during fetch: ${err} (retry ${number})`))
+const tryGetToken = (retry, number) => getToken()
+    .then(token => token)
+    .catch(err => retry(`Error when attempting to retrieve token: ${err} (retry ${number})`))
 
 
 export const authenticatedFetch = (dispatch, relativeUrl, init, returnJson = true, baseUrl = defaultBasePath) => {
-    const authContext = GetAuthContext()
     return PromiseRetry(
-        tryGetToken(authContext),
+        tryGetToken,
         defaultOptions
     ).then(token => {
         const authenticatedInit = initWithAuth(init, token)

--- a/src/services/msalService.js
+++ b/src/services/msalService.js
@@ -75,6 +75,9 @@ const extractAliasFromUserName = (userName) => {
 export const getToken = (scopes) => getAuthContext()
     .acquireTokenSilent(scopes)
 
+export const loginInProgress = () => getAuthContext()._loginInProgress
+
+
 const windowDoesntExistRejection = 'MSAL library cannot function in a headless broswer; the window object must exist'
 const failOnNoWindow = () => Promise.reject(windowDoesntExistRejection)
 const msalServiceHeadlessBrowserMode = ({

--- a/src/services/msalService.js
+++ b/src/services/msalService.js
@@ -7,7 +7,9 @@ export const clientId = CLIENT_ID //From config
 export const authVersion = 'msal'
 
 const defaultScopes = [clientId]
+// eslint-disable-next-line no-undef
 const authority = 'https://login.microsoftonline.com/' + AAD_TENANT
+
 export const getAuthContext = () =>
 {
     if(typeof window !== 'undefined' && !!window)
@@ -32,9 +34,9 @@ export const getAuthContext = () =>
 export const login = (dispatch) => {
     if(typeof window !== 'undefined' && !!window)
     {
-        GetAuthContext().loginRedirect()
+        getAuthContext().loginRedirect()
         .then(
-            () => dispatch(authActions.userLoggedIn(GetAuthContext().getUser())),
+            () => dispatch(authActions.userLoggedIn(getAuthContext().getUser())),
             err => dispatch(authActions.userLoginError(err))
         )
     }
@@ -46,7 +48,7 @@ export const login = (dispatch) => {
 
 export const logOut = (dispatch) => {
     getAuthContext().logOut()
-    dispatch(userLoggedOut())
+    dispatch(authActions.userLoggedOut())
 }
 
 export const clearCache = () => {
@@ -74,8 +76,8 @@ const extractAliasFromUserName = (userName) => {
     return userName.slice(0, userName.indexOf('@'))
 }
 
-export const getToken = () => getAuthContext()
-    .acquireTokenSilent(defaultScopes)
+export const getToken = (scopes) => getAuthContext()
+    .acquireTokenSilent(scopes)
 
 const windowDoesntExistRejection = 'MSAL library cannot function in a headless broswer; the window object must exist'
 const failOnNoWindow = () => Promise.reject(windowDoesntExistRejection)

--- a/src/services/msalService.js
+++ b/src/services/msalService.js
@@ -1,14 +1,12 @@
 import { UserAgentApplication } from 'msal'
 import * as authActions from '../actions/authActions'
+import config from 'config'
 
-// eslint-disable-next-line no-undef
-export const clientId = CLIENT_ID //From config
-
+export const clientId = config.clientId
 export const authVersion = 'msal'
 
 const defaultScopes = [clientId]
-// eslint-disable-next-line no-undef
-const authority = 'https://login.microsoftonline.com/' + AAD_TENANT
+const authority = config.aadInstance + config.aadTenant
 
 export const getAuthContext = () =>
 {
@@ -18,12 +16,10 @@ export const getAuthContext = () =>
         ? window.msal
         : new UserAgentApplication(
             clientId,
-            // eslint-disable-next-line no-undef
             authority,
             tokenRetrieved,
             {
-                // eslint-disable-next-line no-undef
-                redirectUri: AUTH_REDIRECT_URI, //From config
+                redirectUri: config.authRedirectUri,
                 validateAuthority: true
             }
         )

--- a/src/services/msalService.js
+++ b/src/services/msalService.js
@@ -1,0 +1,48 @@
+import { UserAgentApplication } from 'msal'
+
+// eslint-disable-next-line no-undef
+export const clientId = CLIENT_ID //From config
+
+
+export const getAuthContext = () =>
+{
+    if(typeof window !== 'undefined' && !!window)
+    {
+        return window.msal
+        ? window.msal
+        : new UserAgentApplication(
+            clientId,
+            // eslint-disable-next-line no-undef
+            'https://login.microsoftonline.com/' + AAD_TENANT,
+            tokenRetrieved,
+            {
+                // eslint-disable-next-line no-undef
+                redirectUri: AUTH_REDIRECT_URI, //From config
+                validateAuthority: true
+            }
+        )
+    }
+    return msalServiceHeadlessBrowserMode
+}
+
+
+const windowDoesntExistRejection = 'MSAL library cannot function in a headless broswer; the window object must exist'
+const failOnNoWindow = () => Promise.reject(windowDoesntExistRejection)
+const msalServiceHeadlessBrowserMode = ({
+    loginRedirect: () => {},
+    loginPopup: failOnNoWindow,
+    logout: () => {},
+    acquireTokenSilent: failOnNoWindow,
+    acquireTokenPopup: failOnNoWindow,
+    acquireTokenRedirect: () => {},
+    getUser: () => null
+})
+
+const tokenRetrieved =
+() =>
+{
+    //we don't store the token ourselves,
+    //we retrieve it from the cache or remote STS on each request
+}
+
+export default getAuthContext

--- a/src/services/msalService.js
+++ b/src/services/msalService.js
@@ -1,9 +1,13 @@
 import { UserAgentApplication } from 'msal'
+import * as authActions from '../actions/authActions'
 
 // eslint-disable-next-line no-undef
 export const clientId = CLIENT_ID //From config
 
+export const authVersion = 'msal'
 
+const defaultScopes = [clientId]
+const authority = 'https://login.microsoftonline.com/' + AAD_TENANT
 export const getAuthContext = () =>
 {
     if(typeof window !== 'undefined' && !!window)
@@ -13,7 +17,7 @@ export const getAuthContext = () =>
         : new UserAgentApplication(
             clientId,
             // eslint-disable-next-line no-undef
-            'https://login.microsoftonline.com/' + AAD_TENANT,
+            authority,
             tokenRetrieved,
             {
                 // eslint-disable-next-line no-undef
@@ -25,6 +29,53 @@ export const getAuthContext = () =>
     return msalServiceHeadlessBrowserMode
 }
 
+export const login = (dispatch) => {
+    if(typeof window !== 'undefined' && !!window)
+    {
+        GetAuthContext().loginRedirect()
+        .then(
+            () => dispatch(authActions.userLoggedIn(GetAuthContext().getUser())),
+            err => dispatch(authActions.userLoginError(err))
+        )
+    }
+    else
+    {
+        dispatch(authActions.userLoginError(windowDoesntExistRejection))
+    }
+}
+
+export const logOut = (dispatch) => {
+    getAuthContext().logOut()
+    dispatch(userLoggedOut())
+}
+
+export const clearCache = () => {
+    getAuthContext().clearCache()
+}
+
+export const isLoggedIn = () => {
+    const context = getAuthContext()
+    const user = context.getUser()
+    return user
+        ? !!(context.getCachedToken({scopes: defaultScopes, authority}, user))
+        : false
+}
+
+export const getUserAlias = (passedInUser) => {
+    const user = passedInUser
+        ? passedInUser
+        : getAuthContext().getUser()
+    return (user && user.displayableId)
+        ? extractAliasFromUserName(user.displayableId)
+        : null
+}
+
+const extractAliasFromUserName = (userName) => {
+    return userName.slice(0, userName.indexOf('@'))
+}
+
+export const getToken = () => getAuthContext()
+    .acquireTokenSilent(defaultScopes)
 
 const windowDoesntExistRejection = 'MSAL library cannot function in a headless broswer; the window object must exist'
 const failOnNoWindow = () => Promise.reject(windowDoesntExistRejection)

--- a/src/services/playbookService.js
+++ b/src/services/playbookService.js
@@ -1,12 +1,14 @@
 import moment from 'moment'
 import ByPath from 'object-path'
+import * as eventTypeActions from '../actions/eventTypeActions'
+import * as eventActions from '../actions/eventActions'
 
 export const IsBootstrapNeeded = (props) => !props.eventType && !props.isFetching
 
 export const BootstrapIfNeeded = (props) => {
     if(IsBootstrapNeeded(props))
     {
-        props.dispatch(props.eventTypeActions.fetchEventType(props.eventTypeId))
+        props.dispatch(eventTypeActions.fetchEventType(props.eventTypeId))
     }
 }
 
@@ -137,7 +139,7 @@ export const LoadTextFromEvent = (event, eventType, ticket, engagement) => {
     return !!(event.data)
   }
   
-export const publishEvent = (incidentId, eventActions, dispatch) => (filledTemplate) => () => {
+export const publishEvent = (incidentId, filledTemplate) => () => (dispatch) => {
     const parsedTemplate = JSON.parse(filledTemplate)
     dispatch(eventActions.postEvent(incidentId, parsedTemplate.id, parsedTemplate.data))
 }

--- a/test/components/Auth/EnsureLoggedInTest.js
+++ b/test/components/Auth/EnsureLoggedInTest.js
@@ -2,7 +2,6 @@
 import { expect } from 'chai'
 import React from 'react'
 import createComponent from '../../helpers/shallowRenderHelper'
-import GetMockADAL from '../../helpers/mockAdal'
 import GetMockStore from '../../helpers/mockReduxStore'
 import { EnsureLoggedInContainer, mapStateToProps } from '../../../src/components/Auth/EnsureLoggedIn'
 import Login from '../../../src/components/Auth/Login'
@@ -15,19 +14,16 @@ const children = <div></div>
 const errorState = {
     error: 'Test Error',
     isLoggedIn: true,
-    ADAL: GetMockADAL(null),
     store: GetMockStore({auth:{error:'Test Error'}})
 }
 
 const notLoggedInState = {
     isLoggedIn: false,
-    ADAL: GetMockADAL(null),
     store: GetMockStore({auth:{error:'Test Error'}})
 }
 
 const loggedInState = {
     isLoggedIn: true,
-    ADAL: GetMockADAL(null),
     store: GetMockStore({auth:{error:'Test Error'}})
 }
 

--- a/test/components/Auth/LoginTest.js
+++ b/test/components/Auth/LoginTest.js
@@ -4,157 +4,162 @@ import React from 'react'
 import createComponent from '../../helpers/shallowRenderHelper'
 import { Login, LoginComponentDidMount, mapStateToProps } from '../../../src/components/Auth/Login'
 import GetMockStore from '../../helpers/mockReduxStore'
-import GetMockADAL from '../../helpers/mockAdal'
 import * as authActions from '../../../src/actions/authActions'
 
 
 
-function setup({isLoggedIn, loginInProgress, signInAutomatically, dispatch, ADAL}) {
+function setup({isLoggedIn, loginInProgress, signInAutomatically, dispatch, loginComponentDidMount}) {
     let props = {
         isLoggedIn,
         loginInProgress,
         signInAutomatically,
-        ADAL,
+        loginComponentDidMount,
+        StartLogin: {type:'START_LOGIN'},
         dispatch
     }
 
     return createComponent(Login, props)
 }
 
-const mocks = (ADALWatcher) => {
-    const mockStore = GetMockStore()
-    return {
-        mockStore,
-        mockADAL: GetMockADAL(ADALWatcher)(mockStore.dispatch)
-    }
-}
 
-const loggedIn = ({mockStore, mockADAL}) => ({
+
+const baseCase = (mockStore) => ({
+    dispatch: mockStore.dispatch,
+    StartLogin: {type:'START_LOGIN'},
+    loginComponentDidMount: LoginComponentDidMount({type:'START_LOGIN'})
+})
+
+const loggedIn = (mockStore) => ({
     isLoggedIn: true,
     loginInProgress: false,
     signInAutomatically: true,
-    dispatch: mockStore.dispatch,
-    ADAL: mockADAL
+    ...baseCase(mockStore)
 })
 
-const loginInProgress = ({mockStore, mockADAL}) => ({
+const loginInProgress = (mockStore) => ({
     isLoggedIn: false,
     loginInProgress: true,
     signInAutomatically: true,
-    dispatch: mockStore.dispatch,
-    ADAL: mockADAL
+    ...baseCase(mockStore)
 })
 
-const loggedOutWithSignIn = ({mockStore, mockADAL}) => ({
+const loggedOutWithSignIn = (mockStore) => ({
     isLoggedIn: false,
     loginInProgress: false,
     signInAutomatically: true,
-    dispatch: mockStore.dispatch,
-    ADAL: mockADAL
+    ...baseCase(mockStore)
 })
 
-const loggedOutNoSignIn = ({mockStore, mockADAL}) => ({
+const loggedOutNoSignIn = (mockStore) => ({
     isLoggedIn: false,
     loginInProgress: false,
     signInAutomatically: false,
-    dispatch: mockStore.dispatch,
-    ADAL: mockADAL
+    ...baseCase(mockStore)
 })
 
-describe('Login', function test () {
-    beforeEach( () => {
-        this.loggedInADAL = {}
-        this.loginInProgressADAL = {}
-        this.loggedOutWithSignInADAL = {}
-        this.loggedOutNoSignInADAL = {}
+describe('Login', function () {
+    describe('Render', function () {
+        beforeEach( () => {
+            this.loggedInMock = GetMockStore()
+            this.loginInProgressMock = GetMockStore()
+            this.loggedOutWithSignInMock = GetMockStore()
+            this.loggedOutNoSignInMock = GetMockStore()
 
-        this.loggedInMocks = mocks(this.loggedInADAL)
-        this.loginInProgressMocks = mocks(this.loginInProgressADAL)
-        this.loggedOutWithSignInMocks = mocks(this.loggedOutWithSignInADAL)
-        this.loggedOutNoSignInMocks = mocks(this.loggedOutNoSignInADAL)
+            this.loggedInCase = loggedIn(this.loggedInMock)
+            this.loginInProgressCase = loginInProgress(this.loginInProgressMock)
+            this.loggedOutWithSignInCase = loggedOutWithSignIn(this.loggedOutWithSignInMock)
+            this.loggedOutNoSignInCase = loggedOutNoSignIn(this.loggedOutNoSignInMock)
 
-        this.loggedInCase = loggedIn(this.loggedInMocks)
-        this.loginInProgressCase = loginInProgress(this.loginInProgressMocks)
-        this.loggedOutWithSignInCase = loggedOutWithSignIn(this.loggedOutWithSignInMocks)
-        this.loggedOutNoSignInCase = loggedOutNoSignIn(this.loggedOutNoSignInMocks)
+            this.loggedInComponent = setup(this.loggedInCase)
+            this.loginInProgressComponent = setup(this.loginInProgressCase)
+            this.loggedOutWithSignInComponent = setup(this.loggedOutWithSignInCase)
+            this.loggedOutNoSignInComponent = setup(this.loggedOutNoSignInCase)
+        })
 
-        LoginComponentDidMount(this.loggedInCase)
-        LoginComponentDidMount(this.loginInProgressCase)
-        LoginComponentDidMount(this.loggedOutWithSignInCase)
-        LoginComponentDidMount(this.loggedOutNoSignInCase)
+        it('Should always render a signin button', () => {
+            expect(this.loggedInComponent.type).to.equal('button')
+            expect(this.loginInProgressComponent.type).to.equal('button')
+            expect(this.loggedOutWithSignInComponent.type).to.equal('button')
+            expect(this.loggedOutNoSignInComponent.type).to.equal('button')
+        })
+    
+        it('Should always attempt to log in when signin button is clicked', () => {
+            this.loggedInComponent.props.onClick()
+            expect(this.loggedInMock.getActions()[0].type).to.equal('START_LOGIN')
+            expect(this.loggedInMock.getActions()[1]).to.not.exist
 
-        this.loggedInComponent = setup(this.loggedInCase)
-        this.loginInProgressComponent = setup(this.loginInProgressCase)
-        this.loggedOutWithSignInComponent = setup(this.loggedOutWithSignInCase)
-        this.loggedOutNoSignInComponent = setup(this.loggedOutNoSignInCase)
+            this.loginInProgressComponent.props.onClick()
+            expect(this.loginInProgressMock.getActions()[0].type).to.equal('START_LOGIN')
+            expect(this.loginInProgressMock.getActions()[1]).to.not.exist
+
+            this.loggedOutWithSignInComponent.props.onClick()
+            expect(this.loggedOutWithSignInMock.getActions()[0].type).to.equal('START_LOGIN')
+            expect(this.loggedOutWithSignInMock.getActions()[1]).to.not.exist
+
+            this.loggedOutNoSignInComponent.props.onClick()
+            expect(this.loggedOutNoSignInMock.getActions()[0].type).to.equal('START_LOGIN')
+            expect(this.loggedOutNoSignInMock.getActions()[1]).to.not.exist
+        })
     })
 
-    it('Should attempt to log in when user is signed out and has signInAutomatically as true', () => {
-        expect(this.loggedOutWithSignInADAL.loginCalled).to.be.true
-        expect(this.loggedOutWithSignInMocks.mockStore.getActions()[0].type).to.equal(authActions.loginInProgress().type)
+    describe('LoginComponentDidMount', function () {
+        beforeEach( () => {
+            this.loggedInMock = GetMockStore()
+            this.loginInProgressMock = GetMockStore()
+            this.loggedOutWithSignInMock = GetMockStore()
+            this.loggedOutNoSignInMock = GetMockStore()
+
+            this.loggedInCase = loggedIn(this.loggedInMock)
+            this.loginInProgressCase = loginInProgress(this.loginInProgressMock)
+            this.loggedOutWithSignInCase = loggedOutWithSignIn(this.loggedOutWithSignInMock)
+            this.loggedOutNoSignInCase = loggedOutNoSignIn(this.loggedOutNoSignInMock)
+    
+            this.loggedInCase.loginComponentDidMount(this.loggedInCase)
+            this.loginInProgressCase.loginComponentDidMount(this.loginInProgressCase)
+            this.loggedOutWithSignInCase.loginComponentDidMount(this.loggedOutWithSignInCase)
+            this.loggedOutNoSignInCase.loginComponentDidMount(this.loggedOutNoSignInCase)
+        })
+
+        it('Should attempt to log in when user is signed out and has signInAutomatically as true', () => {
+            expect(this.loggedOutWithSignInMock.getActions()[0].type).to.equal('START_LOGIN')
+            expect(this.loggedOutWithSignInMock.getActions()[1]).to.not.exist
+        })
+
+        it('Should not attempt to log in when user is signed in, a login is already in progress, or signInAutomatically is false', () => {
+            expect(this.loggedInMock.getActions()[0]).to.not.exist
+    
+            expect(this.loginInProgressMock.getActions()[0]).to.not.exist
+    
+            expect(this.loggedOutNoSignInMock.getActions()[0]).to.not.exist
+        })
+    
     })
-
-    it('Should not attempt to log in when user is signed in, a login is already in progress, or signInAutomatically is false', () => {
-        expect(this.loggedInADAL.loginCalled).to.not.exist
-        expect(this.loggedInMocks.mockStore.getActions()[0]).to.not.exist
-
-        expect(this.loginInProgressADAL.loginCalled).to.not.exist
-        expect(this.loginInProgressMocks.mockStore.getActions()[0]).to.not.exist
-
-        expect(this.loggedOutNoSignInADAL.loginCalled).to.not.exist
-        expect(this.loggedOutNoSignInMocks.mockStore.getActions()[0]).to.not.exist
+    describe('MapStateToProps', function test () {
+        it('Should correctly generate an args object from state', () => {
+            const inputStateDefault = {
+                auth: {
+                    isLoggedIn: true,
+                    loginInProgress: true,
+                    signInAutomatically: true
+                }
+            }
+            const expectedResultFromDefault = {
+                isLoggedIn: true,
+                loginInProgress: true,
+                signInAutomatically: true
+            }
+    
+            const result = mapStateToProps(inputStateDefault)
+    
+            expect(result.isLoggedIn).to.equal(expectedResultFromDefault.isLoggedIn)
+            expect(result.loginInProgress).to.equal(expectedResultFromDefault.loginInProgress)
+            expect(result.signInAutomatically).to.equal(expectedResultFromDefault.signInAutomatically)
+        })
     })
+    
 
-    it('Should always render a signin button', () => {
-        expect(this.loggedInComponent.type).to.equal('button')
-        expect(this.loginInProgressComponent.type).to.equal('button')
-        expect(this.loggedOutWithSignInComponent.type).to.equal('button')
-        expect(this.loggedOutNoSignInComponent.type).to.equal('button')
-    })
 
-    it('Should always attempt to log in when signin button is clicked', () => {
-        this.loggedInComponent.props.onClick()
-        expect(this.loggedInADAL.loginCalled).to.be.true
-        expect(this.loggedInMocks.mockStore.getActions()[0].type).to.equal(authActions.loginInProgress().type)
-
-        this.loginInProgressComponent.props.onClick()
-        expect(this.loggedInADAL.loginCalled).to.be.true
-        expect(this.loggedInMocks.mockStore.getActions()[0].type).to.equal(authActions.loginInProgress().type)
-
-        this.loggedOutWithSignInComponent.props.onClick()
-        expect(this.loggedInADAL.loginCalled).to.be.true
-        expect(this.loggedInMocks.mockStore.getActions()[0].type).to.equal(authActions.loginInProgress().type)
-
-        this.loggedOutNoSignInComponent.props.onClick()
-        expect(this.loggedInADAL.loginCalled).to.be.true
-        expect(this.loggedInMocks.mockStore.getActions()[0].type).to.equal(authActions.loginInProgress().type)
-    })
 })
 
-const inputStateDefault = {
-    auth: {
-        isLoggedIn: true,
-        loginInProgress: true,
-        signInAutomatically: true
-    }
-}
 
-const ownPropsDefault = {
-    ADAL: GetMockADAL()
-}
 
-const expectedResultFromDefault = {
-    isLoggedIn: true,
-    loginInProgress: true,
-    signInAutomatically: true
-}
-
-describe('LoginMapStateToProps', function test () {
-    it('Should correctly generate an args object from state', () => {
-        const result = mapStateToProps(inputStateDefault, ownPropsDefault)
-
-        expect(result.isLoggedIn).to.equal(expectedResultFromDefault.isLoggedIn)
-        expect(result.loginInProgress).to.equal(expectedResultFromDefault.loginInProgress)
-        expect(result.signInAutomatically).to.equal(expectedResultFromDefault.signInAutomatically)
-    })
-})

--- a/test/components/Auth/LoginTest.js
+++ b/test/components/Auth/LoginTest.js
@@ -8,13 +8,11 @@ import * as authActions from '../../../src/actions/authActions'
 
 
 
-function setup({isLoggedIn, loginInProgress, signInAutomatically, dispatch, loginComponentDidMount}) {
+function setup({isLoggedIn, loginInProgress, signInAutomatically, dispatch}) {
     let props = {
         isLoggedIn,
         loginInProgress,
         signInAutomatically,
-        loginComponentDidMount,
-        StartLogin: {type:'START_LOGIN'},
         dispatch
     }
 
@@ -24,9 +22,7 @@ function setup({isLoggedIn, loginInProgress, signInAutomatically, dispatch, logi
 
 
 const baseCase = (mockStore) => ({
-    dispatch: mockStore.dispatch,
-    StartLogin: {type:'START_LOGIN'},
-    loginComponentDidMount: LoginComponentDidMount({type:'START_LOGIN'})
+    dispatch: mockStore.dispatch
 })
 
 const loggedIn = (mockStore) => ({
@@ -59,47 +55,76 @@ const loggedOutNoSignIn = (mockStore) => ({
 
 describe('Login', function () {
     describe('Render', function () {
-        beforeEach( () => {
-            this.loggedInMock = GetMockStore()
-            this.loginInProgressMock = GetMockStore()
-            this.loggedOutWithSignInMock = GetMockStore()
-            this.loggedOutNoSignInMock = GetMockStore()
+        describe('When user is logged in', function () {
+            const loggedInMock = GetMockStore()
+            const loggedInCase = loggedIn(loggedInMock)
+            const loggedInComponent = setup(loggedInCase)
 
-            this.loggedInCase = loggedIn(this.loggedInMock)
-            this.loginInProgressCase = loginInProgress(this.loginInProgressMock)
-            this.loggedOutWithSignInCase = loggedOutWithSignIn(this.loggedOutWithSignInMock)
-            this.loggedOutNoSignInCase = loggedOutNoSignIn(this.loggedOutNoSignInMock)
+            it('Should always render a signin button', () => {
+                expect(loggedInComponent.type).to.equal('button')
+            })
 
-            this.loggedInComponent = setup(this.loggedInCase)
-            this.loginInProgressComponent = setup(this.loginInProgressCase)
-            this.loggedOutWithSignInComponent = setup(this.loggedOutWithSignInCase)
-            this.loggedOutNoSignInComponent = setup(this.loggedOutNoSignInCase)
+            it('Should always attempt to log in when signin button is clicked', () => {
+                loggedInComponent.props.onClick()
+                expect(loggedInMock.getActions()[0].type).to.equal('LOGIN_IN_PROGRESS')
+                expect(loggedInMock.getActions()[1].type).to.equal('TEST_LOGIN')
+                expect(loggedInMock.getActions()[2]).to.not.exist
+            })
         })
 
-        it('Should always render a signin button', () => {
-            expect(this.loggedInComponent.type).to.equal('button')
-            expect(this.loginInProgressComponent.type).to.equal('button')
-            expect(this.loggedOutWithSignInComponent.type).to.equal('button')
-            expect(this.loggedOutNoSignInComponent.type).to.equal('button')
+        describe('When signin is in progress', function () {
+            const loginInProgressMock = GetMockStore()
+            const loginInProgressCase = loginInProgress(loginInProgressMock)
+            const loginInProgressComponent = setup(loginInProgressCase)
+            
+            it('Should always render a signin button', () => {
+                expect(loginInProgressComponent.type).to.equal('button')
+            })
+
+            it('Should always attempt to log in when signin button is clicked', () => {
+                loginInProgressComponent.props.onClick()
+                expect(loginInProgressMock.getActions()[0].type).to.equal('LOGIN_IN_PROGRESS')
+                expect(loginInProgressMock.getActions()[1].type).to.equal('TEST_LOGIN')
+                expect(loginInProgressMock.getActions()[2]).to.not.exist
+            })
         })
-    
-        it('Should always attempt to log in when signin button is clicked', () => {
-            this.loggedInComponent.props.onClick()
-            expect(this.loggedInMock.getActions()[0].type).to.equal('START_LOGIN')
-            expect(this.loggedInMock.getActions()[1]).to.not.exist
 
-            this.loginInProgressComponent.props.onClick()
-            expect(this.loginInProgressMock.getActions()[0].type).to.equal('START_LOGIN')
-            expect(this.loginInProgressMock.getActions()[1]).to.not.exist
+        describe('When signed out and automatic signin is enabled', function () {
+            const loggedOutWithSignInMock = GetMockStore()
+            const loggedOutWithSignInCase = loggedOutWithSignIn(loggedOutWithSignInMock)
+            const loggedOutWithSignInComponent = setup(loggedOutWithSignInCase)
 
-            this.loggedOutWithSignInComponent.props.onClick()
-            expect(this.loggedOutWithSignInMock.getActions()[0].type).to.equal('START_LOGIN')
-            expect(this.loggedOutWithSignInMock.getActions()[1]).to.not.exist
+            it('Should always render a signin button', () => {
+                expect(loggedOutWithSignInComponent.type).to.equal('button')
+            })
 
-            this.loggedOutNoSignInComponent.props.onClick()
-            expect(this.loggedOutNoSignInMock.getActions()[0].type).to.equal('START_LOGIN')
-            expect(this.loggedOutNoSignInMock.getActions()[1]).to.not.exist
+            it('Should always attempt to log in when signin button is clicked', () => {
+                loggedOutWithSignInComponent.props.onClick()
+                expect(loggedOutWithSignInMock.getActions()[0].type).to.equal('LOGIN_IN_PROGRESS')
+                expect(loggedOutWithSignInMock.getActions()[1].type).to.equal('TEST_LOGIN')
+                expect(loggedOutWithSignInMock.getActions()[2]).to.not.exist
+            })
         })
+
+        describe('When signed out and automatic signin is disabled', function () {
+            const loggedOutNoSignInMock = GetMockStore()
+            const loggedOutNoSignInCase = loggedOutNoSignIn(loggedOutNoSignInMock)
+            const loggedOutNoSignInComponent = setup(loggedOutNoSignInCase)
+
+            it('Should always render a signin button', () => {
+                expect(loggedOutNoSignInComponent.type).to.equal('button')
+            })
+        
+            it('Should always attempt to log in when signin button is clicked', () => {
+                loggedOutNoSignInComponent.props.onClick()
+                expect(loggedOutNoSignInMock.getActions()[0].type).to.equal('LOGIN_IN_PROGRESS')
+                expect(loggedOutNoSignInMock.getActions()[1].type).to.equal('TEST_LOGIN')
+                expect(loggedOutNoSignInMock.getActions()[2]).to.not.exist
+            })
+        })
+
+
+        
     })
 
     describe('LoginComponentDidMount', function () {
@@ -114,15 +139,16 @@ describe('Login', function () {
             this.loggedOutWithSignInCase = loggedOutWithSignIn(this.loggedOutWithSignInMock)
             this.loggedOutNoSignInCase = loggedOutNoSignIn(this.loggedOutNoSignInMock)
     
-            this.loggedInCase.loginComponentDidMount(this.loggedInCase)
-            this.loginInProgressCase.loginComponentDidMount(this.loginInProgressCase)
-            this.loggedOutWithSignInCase.loginComponentDidMount(this.loggedOutWithSignInCase)
-            this.loggedOutNoSignInCase.loginComponentDidMount(this.loggedOutNoSignInCase)
+            LoginComponentDidMount(this.loggedInCase)
+            LoginComponentDidMount(this.loginInProgressCase)
+            LoginComponentDidMount(this.loggedOutWithSignInCase)
+            LoginComponentDidMount(this.loggedOutNoSignInCase)
         })
 
         it('Should attempt to log in when user is signed out and has signInAutomatically as true', () => {
-            expect(this.loggedOutWithSignInMock.getActions()[0].type).to.equal('START_LOGIN')
-            expect(this.loggedOutWithSignInMock.getActions()[1]).to.not.exist
+            expect(this.loggedOutWithSignInMock.getActions()[0].type).to.equal('LOGIN_IN_PROGRESS')
+            expect(this.loggedOutWithSignInMock.getActions()[1].type).to.equal('TEST_LOGIN')
+            expect(this.loggedOutWithSignInMock.getActions()[2]).to.not.exist
         })
 
         it('Should not attempt to log in when user is signed in, a login is already in progress, or signInAutomatically is false', () => {

--- a/test/components/Search/CreateIncidentTest.js
+++ b/test/components/Search/CreateIncidentTest.js
@@ -71,12 +71,7 @@ const inputState = {
     }
 }
 
-const inputIncidentActions = {
-    TestKey: 'TestValue'
-}
-
 const expectedResult = {
-    ticketLookup: {1: {id:100}},
     input: 'test input',
     ticketSystem: {
         id: 1
@@ -89,12 +84,10 @@ const expectedResult = {
 
 describe('CreateIncidentMapStateToProps', () => {
     it('Should correctly generate an args object from state', () => {
-        const result = mapStateToProps(inputIncidentActions)(inputState)
+        const result = mapStateToProps(inputState)
 
-        expect(result.ticketLookup[1].id).to.equal(expectedResult.ticketLookup[1].id)
         expect(result.input).to.equal(expectedResult.input)
         expect(result.ticketSystem.id).to.equal(expectedResult.ticketSystem.id)
         expect(result.creationError).to.equal(expectedResult.creationError)
-        expect(result.incidentActions.TestKey).to.equal(expectedResult.incidentActions.TestKey)
     })
 })

--- a/test/components/Search/CreateIncidentTest.js
+++ b/test/components/Search/CreateIncidentTest.js
@@ -28,14 +28,14 @@ describe('CreateIncident', function testCreateIncident () {
         this.withInput = setup(this.testInput, '')
     })
 
-    it('Should render a div with text field and FlatButtonStyled', function createIncidentRenderDiv () {
-        expect(this.defaultCase.type).to.equal('div')
+    it('Should render a form with text field and FlatButtonStyled', function createIncidentRenderDiv () {
+        expect(this.defaultCase.type).to.equal('form')
         expect(this.defaultCase.props.children[0].type).to.equal(TextField)
         expect(this.defaultCase.props.children[1].type).to.equal(FlatButtonStyled)
-        expect(this.withError.type).to.equal('div')
+        expect(this.withError.type).to.equal('form')
         expect(this.withError.props.children[0].type).to.equal(TextField)
         expect(this.withError.props.children[1].type).to.equal(FlatButtonStyled)
-        expect(this.withInput.type).to.equal('div')
+        expect(this.withInput.type).to.equal('form')
         expect(this.withInput.props.children[0].type).to.equal(TextField)
         expect(this.withInput.props.children[1].type).to.equal(FlatButtonStyled)
     })

--- a/test/components/Timeline/EventsTest.js
+++ b/test/components/Timeline/EventsTest.js
@@ -117,8 +117,7 @@ const eventTen = {
 
 const events = [eventZero, eventOne, eventTwo, eventThree, eventFour, 
     eventFive, eventSix, eventSeven, eventEight, eventNine, eventTen]
-const eventActions = null
-const eventTypeActions = null
+
 const ticketId = '2'
 const incidentId = null
 const eventTypes = [eventTypeZero, eventTypeOne, eventTypeTwo, 
@@ -128,7 +127,7 @@ const eventTypes = [eventTypeZero, eventTypeOne, eventTypeTwo,
 describe('Events', function test () {
     beforeEach( () => {
         console.log(events[5].data)
-        this.output = Events(events, eventActions, eventTypeActions, ticketId, incidentId, eventTypes)
+        this.output = Events(events, ticketId, incidentId, eventTypes)
     })
 
     it('Should return an array of Events', () => {

--- a/test/reducers/authReducerTest.js
+++ b/test/reducers/authReducerTest.js
@@ -3,8 +3,6 @@ import { expect } from 'chai';
 import * as authActions from '../../src/actions/authActions.js'
 import authReducer from '../../src/reducers/authReducer.js'
 
-const generatedAuthReducer = authReducer(dummyAuthContext, dummyClientId)
-
 const dummyClientId = 'Not my actual clientId'
 
 const dummyAuthContext = {
@@ -60,20 +58,20 @@ describe('authReducer', function test () {
         this.testToken = 'Test Token'
         this.testError = 'Test Error'
 
-        this.onLoginFromDefault = generatedAuthReducer(defaultState, authActions.userLoggedIn(testUser))
-        this.onLoginFromLoggedOut = generatedAuthReducer(loggedOutState, authActions.userLoggedIn(testUser))
-        this.onLoginFromError = generatedAuthReducer(loginErrorState, authActions.userLoggedIn(testUser))
-        this.onLoginFromInProgress = generatedAuthReducer(loginInProgressState, authActions.userLoggedIn(testUser))
+        this.onLoginFromDefault = authReducer(defaultState, authActions.userLoggedIn(testUser))
+        this.onLoginFromLoggedOut = authReducer(loggedOutState, authActions.userLoggedIn(testUser))
+        this.onLoginFromError = authReducer(loginErrorState, authActions.userLoggedIn(testUser))
+        this.onLoginFromInProgress = authReducer(loginInProgressState, authActions.userLoggedIn(testUser))
         
-        this.onErrorFromDefault = generatedAuthReducer(defaultState, authActions.userLoginError(this.testError))
-        this.onErrorFromLoggedIn = generatedAuthReducer(loggedInState, authActions.userLoginError(this.testError))
-        this.onErrorFromInProgress = generatedAuthReducer(loginInProgressState, authActions.userLoginError(this.testError))
+        this.onErrorFromDefault = authReducer(defaultState, authActions.userLoginError(this.testError))
+        this.onErrorFromLoggedIn = authReducer(loggedInState, authActions.userLoginError(this.testError))
+        this.onErrorFromInProgress = authReducer(loginInProgressState, authActions.userLoginError(this.testError))
         
-        this.onLogoutFromError = generatedAuthReducer(loginErrorState, authActions.userLoggedOut())
-        this.onLogoutFromLoggedIn = generatedAuthReducer(loggedInState, authActions.userLoggedOut())
+        this.onLogoutFromError = authReducer(loginErrorState, authActions.userLoggedOut())
+        this.onLogoutFromLoggedIn = authReducer(loggedInState, authActions.userLoggedOut())
 
-        this.onInProgressFromDefault = generatedAuthReducer(defaultState, authActions.loginInProgress())
-        this.onInProgressFromError = generatedAuthReducer(loginErrorState, authActions.loginInProgress())
+        this.onInProgressFromDefault = authReducer(defaultState, authActions.loginInProgress())
+        this.onInProgressFromError = authReducer(loginErrorState, authActions.loginInProgress())
     })
 
     it('Should set isLoggedIn to true on login', () => {


### PR DESCRIPTION
Does not yet flip the switch to the V2 library (MSAL), as there are compatibility concerns to resolve before we can change the Gateway to the new login type. Adds an abstraction layer to allow choosing an auth library based on config.

Most significant change is that there's no more need to pass siaContext or 'actions' collections around.