### PR TITLE
Sticky Extension State

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bower_components/
 .idea
 /.vs/slnx.sqlite
 .vscode
+.vs
 
 # Temp directory used by tests
 temp

--- a/dist/assets/extension.html
+++ b/dist/assets/extension.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 </head>
 <body>
-  <div id="app" style="height:1000px" >APPLICATION CONTENT</div>
+  <div id="siaApp" style="height:1000px" >APPLICATION CONTENT</div>
   <script type="text/javascript" src="app.js"></script>
 </body>
 </html>

--- a/dist/assets/manifest.json
+++ b/dist/assets/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "SIA",
     "description": "SIA",
-    "version": "0.0.0.1",
+    "version": "0.0.0.2",
     "manifest_version": 2,
     "browser_action": {
         "default_popup": "extension.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5221,6 +5221,16 @@
         "lodash._root": "3.0.1"
       }
     },
+    "lodash.forin": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-4.4.0.tgz",
+      "integrity": "sha1-XT8grlZAEfvog4H32YlJyclRlzE="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -5232,6 +5242,11 @@
       "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.keys": {
       "version": "3.1.2",
@@ -5259,8 +5274,12 @@
     "lodash.pickby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
-      "dev": true
+      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.throttle": {
       "version": "4.1.1",
@@ -5273,6 +5292,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "lodash.unset": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
+      "integrity": "sha1-Nw0dPoW3Kn4bDN8tJyEhMG8j5O0="
     },
     "lodash.words": {
       "version": "3.2.0",
@@ -7639,6 +7663,24 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.2.3.tgz",
       "integrity": "sha1-GzrSmdqRy0G6MNaOO28CRHX7nhs="
+    },
+    "redux-persist": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-5.4.0.tgz",
+      "integrity": "sha512-Ohp7g5WRx2rDyDk/bKKCgbD3ES6ahGPWxFEp3QPx2opwst0jJEbZKigZtQewUeJZnomN/7Zo3QglPDOZ6EdYEw=="
+    },
+    "redux-persist-transform-filter": {
+      "version": "0.0.16",
+      "resolved": "https://registry.npmjs.org/redux-persist-transform-filter/-/redux-persist-transform-filter-0.0.16.tgz",
+      "integrity": "sha512-P7vBmrhOlGWO6Qtw1VoJ2cPzlb4PdPtJjppcJK0uSmcg5TCYxBVla27mxBZzday4CCy0wsYqDq+UI/1E84Yk9Q==",
+      "requires": {
+        "lodash.forin": "4.4.0",
+        "lodash.get": "4.4.2",
+        "lodash.isempty": "4.4.0",
+        "lodash.pickby": "4.6.0",
+        "lodash.set": "4.3.2",
+        "lodash.unset": "4.5.2"
+      }
     },
     "redux-thunk": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -95,6 +95,8 @@
     "paginated-redux": "^0.2.2",
     "promise-retry": "^1.1.1",
     "redux-mock-store": "^1.2.3",
+    "redux-persist": "^5.4.0",
+    "redux-persist-transform-filter": "0.0.16",
     "redux-thunk": "^2.2.0"
   }
 }

--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -103,7 +103,7 @@ const fullIncidentInfoLoaded = (incident, ticket, ticketSystem, preferences) => 
 
 const isTicketInfoRecent = (ticket, preferences) => ticket
 && ticket.lastRefresh
-&& ticket.lastRefresh.isAfter(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds'))
+&& moment(ticket.lastRefresh).isAfter(moment().subtract(preferences.refreshIntervalInSeconds, 'seconds'))
 
 export const getIncidentsActionSet = ({
     try: () => ({

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { Redirect } from 'react-router'
+
+
+
+export const Home = ({ ticket }) => {
+    if (ticket && ticket.originId) {
+        return <Redirect to={`/tickets/${ticket.originId}`} />
+    }
+    return <Redirect to={'/search'} />
+}
+
+export const mapStateToProps = (state) => {
+    // this gross thing finds all actual tickets, omitting the refresh metadata, and then picks the most recently visited one out
+    // the sort function works because the dates are UTC and thus lexically sortable to start with
+    return {
+        ticket: (state.tickets && state.tickets.map) ? Object.values(state.tickets.map).filter(ele => { return ele.lastRefresh })
+                                        .sort((a, b) => { return (a.lastRefresh > b.lastRefresh) ? -1 : 1 })[0]
+                                        : undefined
+    }
+}
+
+export default connect(mapStateToProps)(Home)
+

--- a/src/components/Incident/DisplayIncident.js
+++ b/src/components/Incident/DisplayIncident.js
@@ -51,18 +51,18 @@ export const IncidentSummary = (incident, ticket, ticketSystem, ticketId, dispat
         [
             [
                 (key) =>
-                    <a href={`${ticketSystem.ticketUriPrefix}${ticket.originId}${ticketSystem.ticketUriSuffix}`} key={key}>
+                    <a href={`${ticketSystem.ticketUriPrefix}${ticket.originId}${ticketSystem.ticketUriSuffix}`} key={key} target="_blank">
                         {ticket.originId}
                     </a>,
                 (key) =>
                     <div key={key}>
-                        Sev 2 {ticket.severity}
+                        {ticket.severity}
                     </div>
             ],
             [
                 (key) =>
                     <div key={key}>
-                        IM: TBD {ticket.imName}
+                        {ticket.imName}
                     </div>,
                 (key) =>
                     <IconButtonStyled tooltip="Edit IM" key={key}>

--- a/src/components/TopNav/NavMenu.js
+++ b/src/components/TopNav/NavMenu.js
@@ -20,7 +20,7 @@ export const NavMenu = ({dispatch, alias}) =>
     targetOrigin={{horizontal: 'left', vertical: 'top'}}
 >
     <MenuItem primaryText={ alias }/>
-    <MenuItem primaryText={<Link to="/" >Incident Search</Link>} />
+    <MenuItem primaryText={<Link to="/search" >Incident Search</Link>} />
     <MenuItem primaryText={<Link to="/" onClick={() => dispatch(auth.logOut)}>LogOut</Link>} />
     <MenuItem primaryText={<Link to="/debug" >Debug</Link>} />
 </IconMenu>

--- a/src/configureStore.js
+++ b/src/configureStore.js
@@ -1,0 +1,17 @@
+import { createStore, applyMiddleware, compose, combineReducers } from 'redux'
+import thunk from 'redux-thunk'
+import establishSignalRConnection from './services/signalRService'
+import { ListenForScreenSize } from './actions/styleActions'
+import incidentApp from './reducers'
+import { persistStore } from 'redux-persist'
+
+const reducer = combineReducers(incidentApp)
+
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
+export const store = createStore(reducer, composeEnhancers(applyMiddleware(thunk)))
+export const persistor = persistStore(store)
+
+establishSignalRConnection(store.dispatch)
+
+ListenForScreenSize(window, store)
+

--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 </head>
 <body>
-  <div id="app">APPLICATION CONTENT</div>
+  <div id="siaApp">APPLICATION CONTENT</div>
 
   <script>__REACT_DEVTOOLS_GLOBAL_HOOK__ = parent.__REACT_DEVTOOLS_GLOBAL_HOOK__</script>
   <script type="text/javascript" src="/assets/app.js"></script>

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import Ticket from './components/Incident/Ticket'
 import CompareTickets from './components/Incident/CompareTickets'
 import EnsureLoggedInContainer from './components/Auth/EnsureLoggedIn'
 import incidentRedirect from './components/Incident/incidentRedirect'
+import Home from './components/Home'
 import TopNav from './components/TopNav/TopNav'
 import Debug from './components/Debug'
 import { store, persistor } from './configureStore'
@@ -36,7 +37,8 @@ class MainComponent extends React.Component {
                 <Router history={history} >
                   <div>
                     <TopNav />
-                    <Route exact path="/" component={CreateIncident} />
+                    <Route exact path="/" component={Home} />
+                    <Route exact path="/search" component={CreateIncident} />
                     <Route exact path="/tickets/:ticketId" component={Ticket} />
                     <Route path="/tickets/:firstTicketId/compare/:secondTicketId" component={CompareTickets} />
                     <Route path="/incidents/:incidentId" component={incidentRedirect} />

--- a/src/index.js
+++ b/src/index.js
@@ -59,5 +59,5 @@ class MainComponent extends React.Component {
 }
 
 // Render the main component into the dom
-ReactDOM.render(<MainComponent />, document.getElementById('app'))
+ReactDOM.render(<MainComponent />, document.getElementById('siaApp'))
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,10 @@
 import 'core-js/fn/object/assign'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { createStore, applyMiddleware, compose } from 'redux'
 import { Provider } from 'react-redux'
-import incidentApp from './reducers'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 import injectTapEventPlugin from 'react-tap-event-plugin'
-import thunk from 'redux-thunk'
 injectTapEventPlugin()
 require('./styles/App.css')
 import {
@@ -22,15 +19,10 @@ import EnsureLoggedInContainer from './components/Auth/EnsureLoggedIn'
 import incidentRedirect from './components/Incident/incidentRedirect'
 import TopNav from './components/TopNav/TopNav'
 import Debug from './components/Debug'
-import { ListenForScreenSize } from './actions/styleActions'
-import establishSignalRConnection from './services/signalRService'
+import { store, persistor } from './configureStore'
+import { PersistGate } from 'redux-persist/lib/integration/react'
 
-const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
-export const store = createStore(incidentApp(), composeEnhancers(applyMiddleware(thunk)))
 
-establishSignalRConnection(store.dispatch)
-
-ListenForScreenSize(window, store)
 const history = createBrowserHistory()
 
 class MainComponent extends React.Component {
@@ -38,20 +30,22 @@ class MainComponent extends React.Component {
     return (
       <MuiThemeProvider muiTheme={getMuiTheme()}>
         <Provider store={store}>
-          <div>
-            <EnsureLoggedInContainer>
-              <Router history={history} >
-                <div>
-                  <TopNav />
-                  <Route exact path="/" component={CreateIncident} />
-                  <Route exact path="/tickets/:ticketId" component={Ticket} />
-                  <Route path="/tickets/:firstTicketId/compare/:secondTicketId" component={CompareTickets} />
-                  <Route path="/incidents/:incidentId" component={incidentRedirect} />
-                  <Route path="/debug" render={() => <Debug />}/>
-                </div>
-              </Router>
-            </EnsureLoggedInContainer>
-          </div>
+          <PersistGate persistor={persistor}>
+            <div>
+              <EnsureLoggedInContainer>
+                <Router history={history} >
+                  <div>
+                    <TopNav />
+                    <Route exact path="/" component={CreateIncident} />
+                    <Route exact path="/tickets/:ticketId" component={Ticket} />
+                    <Route path="/tickets/:firstTicketId/compare/:secondTicketId" component={CompareTickets} />
+                    <Route path="/incidents/:incidentId" component={incidentRedirect} />
+                    <Route path="/debug" render={() => <Debug />}/>
+                  </div>
+                </Router>
+              </EnsureLoggedInContainer>
+            </div>
+          </PersistGate>
         </Provider>
       </MuiThemeProvider>
     )

--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ class MainComponent extends React.Component {
                 <Router history={history} >
                   <div>
                     <TopNav />
-                    <Route path="/" component={Home} />
+                    <Route exact path="/" component={Home} />
+                    <Route exact path="/extension.html" component={Home} />
                     <Route path="/search" component={CreateIncident} />
                     <Route path="/tickets/:ticketId" component={Ticket} />
                     <Route path="/tickets/:firstTicketId/compare/:secondTicketId" component={CompareTickets} />

--- a/src/index.js
+++ b/src/index.js
@@ -37,9 +37,9 @@ class MainComponent extends React.Component {
                 <Router history={history} >
                   <div>
                     <TopNav />
-                    <Route exact path="/" component={Home} />
-                    <Route exact path="/search" component={CreateIncident} />
-                    <Route exact path="/tickets/:ticketId" component={Ticket} />
+                    <Route path="/" component={Home} />
+                    <Route path="/search" component={CreateIncident} />
+                    <Route path="/tickets/:ticketId" component={Ticket} />
                     <Route path="/tickets/:firstTicketId/compare/:secondTicketId" component={CompareTickets} />
                     <Route path="/incidents/:incidentId" component={incidentRedirect} />
                     <Route path="/debug" render={() => <Debug />}/>

--- a/src/reducers/eventTypeReducer.js
+++ b/src/reducers/eventTypeReducer.js
@@ -1,6 +1,12 @@
 import * as eventTypeActions from '../actions/eventTypeActions'
 import { mergeToStateById, buildFetching } from './reducerHelpers'
-import { combineReducers } from 'redux'
+import { persistCombineReducers } from 'redux-persist'
+import storage from 'redux-persist/lib/storage' // default: localStorage if web, AsyncStorage if react-native
+
+const persistConfig = {
+    key: 'eventType',
+    storage
+}
 
 const defaultEventTypeCollection = {}
 
@@ -19,7 +25,7 @@ export const records = (state = defaultEventTypeCollection, action) => {
     }
 }
 
-export const eventTypeReducer = combineReducers({
+export const eventTypeReducer = persistCombineReducers(persistConfig, {
     fetching,
     records
 })

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,3 @@
-import { combineReducers } from 'redux'
 import tickets from './ticketReducers'
 import auth from './authReducer'
 import incidents from './incidentReducers'
@@ -9,7 +8,8 @@ import signalR from './signalRReducer'
 import forms from './formReducer'
 import eventTypes from './eventTypeReducer'
 
-const rootReducer = () => combineReducers({
+
+export default {
     incidents,
     auth,
     tickets,
@@ -19,6 +19,4 @@ const rootReducer = () => combineReducers({
     expandSection,
     signalR,
     eventTypes
-})
-
-export default rootReducer
+}

--- a/src/reducers/ticketReducers.js
+++ b/src/reducers/ticketReducers.js
@@ -3,6 +3,8 @@ import { combineReducers } from 'redux'
 import { UPDATE_TICKET_QUERY } from '../actions/ticketActions.js'
 import { RECEIVE_INCIDENTS, CREATE_INCIDENT_SUCCESS, RECEIVE_INCIDENT, FETCH_INCIDENTS_BY_TICKET_ID_SUCCESS } from '../actions/incidentActions.js'
 import config from 'config'
+import { persistReducer } from 'redux-persist'
+import storage from 'redux-persist/lib/storage' // default: localStorage if web, AsyncStorage if react-native
 
 const defaultTicketList = {}
 
@@ -12,22 +14,22 @@ const defaultSystems = config.ticketSystems
 
 const parseTicketsFromIncident = (incident) => {
     var associatedTickets = incident.tickets ? [...incident.tickets] : []
-    if(incident.primaryTicket) {
+    if (incident.primaryTicket) {
         associatedTickets.push(incident.primaryTicket)
     }
-    if(associatedTickets.length) {
+    if (associatedTickets.length) {
         associatedTickets.map(parseTicketFromIncident(incident))
     }
-    
+
     return associatedTickets
 }
 
 const parseTicketFromIncident = (incident) => (ticket) => {
-    if(ticket) {
+    if (ticket) {
         ticket.incidentId = incident.id,
-        ticket.status = 'Active',
-        ticket.title = incident.title,
-        ticket.primaryTicketId = incident.primaryTicket.id
+            ticket.status = 'Active',
+            ticket.title = incident.title,
+            ticket.primaryTicketId = incident.primaryTicket.id
         ticket.lastRefresh = moment().toISOString()
     }
 }
@@ -37,14 +39,14 @@ const addIncidentToState = (state, incident) => {
 }
 
 const addIncidentsToState = (state, incidents) => {
-    let newState = {...state}
+    let newState = { ...state }
     incidents.map(incident => parseTicketsFromIncident(incident)
-                            .map(ticket => newState[ticket.originId] = ticket))
+        .map(ticket => newState[ticket.originId] = ticket))
     return newState
 }
 
 export const map = (state = defaultTicketList, action) => {
-    switch(action.type){
+    switch (action.type) {
         case FETCH_INCIDENTS_BY_TICKET_ID_SUCCESS:
         case RECEIVE_INCIDENTS:
             return addIncidentsToState(state, action.incidents)
@@ -57,11 +59,11 @@ export const map = (state = defaultTicketList, action) => {
 }
 
 export const query = (state = defaultQueryString, action) => {
-    switch(action.type){
+    switch (action.type) {
         case UPDATE_TICKET_QUERY:
             return action.ticketQuery
         case CREATE_INCIDENT_SUCCESS:
-            if(action && action.incident && action.incident.primaryTicket && action.incident.primaryTicket.originId) {
+            if (action && action.incident && action.incident.primaryTicket && action.incident.primaryTicket.originId) {
                 return action.incident.primaryTicket.originId.toString()
             }
             else return state
@@ -71,7 +73,7 @@ export const query = (state = defaultQueryString, action) => {
 }
 
 export const systems = (state = defaultSystems, action) => {
-    switch(action.type){
+    switch (action.type) {
         default:
             return state
     }
@@ -82,17 +84,21 @@ const defaultPreferences = {
 }
 
 export const preferences = (state = defaultPreferences, action) => {
-    switch(action.type){
+    switch (action.type) {
         default:
             return state
     }
 }
 
+const mapRed = persistReducer({
+    key: 'ticket',
+    storage
+}, map)
 const ticketReducer = combineReducers({
-  map,
-  query,
-  systems,
-  preferences
+    map: mapRed,
+    query,
+    systems,
+    preferences
 })
 
 export default ticketReducer

--- a/src/reducers/ticketReducers.js
+++ b/src/reducers/ticketReducers.js
@@ -28,7 +28,7 @@ const parseTicketFromIncident = (incident) => (ticket) => {
         ticket.status = 'Active',
         ticket.title = incident.title,
         ticket.primaryTicketId = incident.primaryTicket.id
-        ticket.lastRefresh = moment()
+        ticket.lastRefresh = moment().toISOString()
     }
 }
 

--- a/src/services/adalService.js
+++ b/src/services/adalService.js
@@ -89,7 +89,8 @@ function createContext(chromeExtension) {
     tenant: config.aadTenant,
     redirectUri: (chromeExtension) ? chrome.identity.getRedirectURL('/extension.html') : config.redirectUri, // eslint-disable-line no-undef
     clientId: clientId,
-    popUp: true
+    popUp: true,
+    cacheLocation: 'localStorage'
   })
 
   //if in chrome extension configure auth accordingly

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,4 +1,4 @@
-div#app {
+div#siaApp {
   font-family: "Segoe UI", arial, sans-serif;
   max-width: 20%;
 }
@@ -53,7 +53,7 @@ div#app {
 
 @media (max-width: 1800px) {
 
-  div#app {
+  div#siaApp {
     max-width: 25%;
   }
 
@@ -61,7 +61,7 @@ div#app {
 
 @media (max-width: 1600px) {
 
-  div#app {
+  div#siaApp {
     max-width: 30%;
   }
 
@@ -69,7 +69,7 @@ div#app {
 
 @media (max-width: 1200px) {
 
-  div#app {
+  div#siaApp {
     max-width: 40%;
   }
 
@@ -77,7 +77,7 @@ div#app {
 
 @media (max-width: 920px) {
 
-  div#app {
+  div#siaApp {
     max-width: 50%;
   }
 
@@ -85,7 +85,7 @@ div#app {
 
 @media (max-width: 768px) {
 
-  div#app {
+  div#siaApp {
     max-width: 75%;
   }
 
@@ -93,7 +93,7 @@ div#app {
 
 @media (max-width: 480px) {
 
-  div#app {
+  div#siaApp {
     max-width: 100%;
   }
 

--- a/test/components/TopNav/NavMenuTest.js
+++ b/test/components/TopNav/NavMenuTest.js
@@ -40,7 +40,7 @@ describe('NavMenu', function test () {
     it('Should render an Incident Search link', () => {
         expect(this.output.props.children[1].type).to.equal(MenuItem)
         expect(this.output.props.children[1].props.primaryText.type).to.equal(Link)
-        expect(this.output.props.children[1].props.primaryText.props.to).to.equal('/')
+        expect(this.output.props.children[1].props.primaryText.props.to).to.equal('/search')
     })
 
     it('Should render a log out link', () => {

--- a/test/components/homeTest.js
+++ b/test/components/homeTest.js
@@ -1,0 +1,81 @@
+'use strict'
+import { expect } from 'chai'
+import React from 'react'
+import createComponent from '../helpers/shallowRenderHelper'
+import GetMockStore from '../helpers/mockReduxStore'
+import { Home, mapStateToProps } from '../../src/components/Home'
+
+const setup = (props, children) => createComponent(Home, props, children)
+
+const children = <div></div>
+
+const noTicketState = { ticket: undefined }
+
+const ticketState = { ticket: {
+    originId: '5507',
+    lastRefresh: '2017-12-29T20:19:32.407Z'
+}}
+
+describe('Home Container Component', function test() {
+    beforeEach(() => {
+        this.noTicketsExistState = setup(noTicketState, children)
+        this.ticketsExistState = setup(ticketState, children)
+    })
+
+    it('Should redirect to search if no tickets', () => {
+        expect(this.noTicketsExistState.props.to).to.equal('/search')
+    })
+    it('Should redirect to most recent ticket if there are tickets', () => {
+        expect(this.ticketsExistState.props.to).to.equal('/tickets/5507')
+    })
+
+})
+
+
+
+describe('home mapStateToProps', function test() {
+    it('should return null if no tickets and fresh state', () => {
+        const noTicketsExistState = { tickets: null }
+        
+        expect(mapStateToProps(noTicketsExistState).ticket).to.be.undefined
+    })
+    it('should return null if no tickets and reloaded state', () => {
+        const noTicketsExistState = {
+            tickets: {
+                map: {
+                  _persist: {
+                    version: -1,
+                    rehydrated: true
+                  }
+                }
+            }}
+        
+        expect(mapStateToProps(noTicketsExistState).ticket).to.be.undefined
+    })
+    it('should return most recent ticket', () =>{
+        const ticketsExistState = {
+                tickets: {
+                    map: {
+                        '5507': {
+                            originId: '5507',
+                            lastRefresh: '2017-12-29T20:19:32.407Z'
+                        },
+                        '5519': {
+                            originId: '5519',
+                            lastRefresh: '2017-12-29T20:19:01.451Z'
+                        },
+                        _persist: {
+                            version: -1,
+                            rehydrated: true
+                        }
+                    }
+                }}
+        
+        expect(mapStateToProps(ticketsExistState).ticket).to.exist
+        expect(mapStateToProps(ticketsExistState).ticket.originId).to.equal('5507')
+
+        })
+})
+
+
+


### PR DESCRIPTION
Pull request persists some of the redux state to local storage, allowing us to return the user to the ticket they were looking at before, unless the request a different ticket.

This change stages some awesome possibilities including:
List of recently visited tickets
Sticky filters

Over time, we will need to prune some of the retained state to avoid blowing the browser out of memory - but this will do for an MVP