### PR TITLE
fix persisting error eventTypeReducer

### DIFF
--- a/src/reducers/eventTypeReducer.js
+++ b/src/reducers/eventTypeReducer.js
@@ -1,8 +1,9 @@
+import { combineReducers } from 'redux'
 import * as eventTypeActions from '../actions/eventTypeActions'
 import { mergeToStateById } from './reducerHelpers/merge'
 import buildFetching from './reducerHelpers/fetching'
 import buildError from './reducerHelpers/error'
-import { persistCombineReducers } from 'redux-persist'
+import { persistReducer } from 'redux-persist'
 import storage from 'redux-persist/lib/storage' // default: localStorage if web, AsyncStorage if react-native
 
 const persistConfig = {
@@ -33,10 +34,12 @@ export const records = (state = defaultEventTypeCollection, action) => {
     }
 }
 
-export const eventTypeReducer = persistCombineReducers(persistConfig, {
+const persistedRecords = persistReducer(persistConfig, records)
+
+export const eventTypeReducer = combineReducers({
     fetching,
     error,
-    records
+    records: persistedRecords
 })
 
 export default eventTypeReducer

--- a/src/reducers/eventTypeReducer.js
+++ b/src/reducers/eventTypeReducer.js
@@ -34,7 +34,7 @@ export const records = (state = defaultEventTypeCollection, action) => {
     }
 }
 
-const persistedRecords = persistReducer(persistConfig, records)
+const persistedRecords = persistReducer({ key: 'eventType', storage }, records)
 
 export const eventTypeReducer = combineReducers({
     fetching,


### PR DESCRIPTION
use of persistCombineReducers caused the eventType errors to hang around and cause display problems.