### PR TITLE
Provide breadcrumbs of prev visited tickets

### DIFF
--- a/src/components/TopNav/NavMenu.js
+++ b/src/components/TopNav/NavMenu.js
@@ -7,19 +7,44 @@ import { Link } from 'react-router-dom'
 import NavigationMenu from 'material-ui/svg-icons/navigation/menu'
 import IconButton from 'material-ui/IconButton'
 import * as auth from 'services/authNService'
+import { _ } from 'underscore'
 
-export const NavMenu = ({ dispatch }) =>
-  <IconMenu
+const Tickets = () => {
+  var persistedTickets  = JSON.parse(localStorage['persist:ticket'])
+  var currentTicketId   = window.location.pathname.match(/(\d+)/)[1]
 
+  var idIsNumericalAndNotCurrentTicket  = (id) => /\d+/.test(id) && id != currentTicketId
+  var addCurrentPageToHistory           = () => { history.push(this.to) }
+  var transformIdToTicketLink           = (id) =>
+    <MenuItem
+      key={'ticket-' + id}
+      primaryText={
+        <Link
+          to={'/tickets/' + id}
+          onClick={ addCurrentPageToHistory }>
+          Ticket {id}
+        </Link>
+      }
+    />
+
+  var ticketIds = _.select(Object.keys(persistedTickets), idIsNumericalAndNotCurrentTicket)
+
+  return ticketIds.map(transformIdToTicketLink)
+}
+
+export const NavMenu = (dispatch) => {
+  return (<IconMenu
     iconButtonElement={<IconButton><NavigationMenu /></IconButton>}
     anchorOrigin={{horizontal: 'left', vertical: 'bottom'}}
     targetOrigin={{horizontal: 'left', vertical: 'top'}}
->
+  >
+    <MenuItem key='search' primaryText={<Link to='/search' >Incident Search</Link>} />
+    <MenuItem key='logout' primaryText={<Link to='/' onClick={ () => dispatch(auth.logOut)}>LogOut</Link> } />
 
-    <MenuItem primaryText={<Link to='/search' >Incident Search</Link>} />
-    <MenuItem primaryText={<Link to='/' onClick={() => dispatch(auth.logOut)}>LogOut</Link>} />
-    <MenuItem primaryText={<Link to='/debug' >Debug</Link>} />
-  </IconMenu>
+    { Tickets() }
+    <MenuItem key='debug' primaryText={<Link to='/debug' >Debug</Link>} />
+  </IconMenu>)
+}
 
 NavMenu.propTypes = {
   dispatch: PropTypes.func


### PR DESCRIPTION
## User Story

As a Sia user, I want to be able to navigate to previously viewed tickets.

Given I am within Sia on an incident ticket page
And I navigate to several other incident ticket pages
When I click on the hamburger dropdown menu
Then I should see a list of incidents
And that list should have all recently visited incidents
And that list should not have the current incident.

## Caveats

As implemented there is no ceiling on the number of incidents displayed within the menu and they are not ordered. Before merging you should verify that this behavior is correct, or adjust the behavior to limit the number of incidents displayed and sort them reverse chronologically by recency of visit.