### PR TITLE
Move coverage to 'npm run test:coverage' instead of 'npm run test'

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,8 +3,12 @@
     ["env"],
     "react"
   ],
+  "env": {
+    "coverage": {
+      "plugins": ["istanbul"]
+    }
+  },
   "plugins": [
-    "istanbul",
     "transform-object-rest-spread",
     "syntax-class-properties",
     "transform-class-properties",

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: node_js
 node_js:
   - "lts/*"
 
+script:
+  - npm run lint
+  - npm run test:coverage
+
 after_success:
   - npm install -g codecov codacy-coverage coveralls
   - codecov

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
     "serve": "node server.js --env=dev",
     "serve:dist": "cross-env NODE_ENV=dist node server.js",
     "start": "node server.js --env=localhost",
-    "test": "nyc cross-env NODE_ENV=test mocha",
-    "test:nocov": "mocha --compilers js:babel-core/register",
-    "test:debug": "mocha --inspect-brk --compilers js:babel-core/register",
-    "test:watch": "karma start --autoWatch=true --singleRun=false"
+    "test": "mocha",
+    "test:debug": "mocha --inspect-brk",
+    "test:watch": "mocha --watch",
+    "test:coverage": "cross-env NODE_ENV=coverage nyc mocha"
   },
   "nyc": {
     "reporter": [

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,4 @@
 test/**/*.js
 --colors
+--require babel-polyfill
+--require babel-core/register


### PR DESCRIPTION
Inspired by @strand 's test:nocov. This should be the default behavior. Coverage instrumentation makes tests really slow.