### PR TITLE
[Maintenance/UX] Remove refresh icon from incident summary.

### DIFF
--- a/src/components/Incident/IncidentSummary.js
+++ b/src/components/Incident/IncidentSummary.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import SyncIcon from 'material-ui/svg-icons/notification/sync'
 import ModeEditIcon from 'material-ui/svg-icons/editor/mode-edit'
 
 import IconButtonStyled from 'components/elements/IconButtonStyled'
@@ -32,10 +31,6 @@ const HeaderRow = (ticketId) => [
     (key) =>
       <strong key={key}>
                 Incident Summary{ticketId ? ` for ${ticketId}` : ''}:
-                &nbsp;
-                <IconButtonStyled tooltip='Refresh'>
-                  <SyncIcon />
-                </IconButtonStyled>
       </strong>
   ]
 ]


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/167166/37988400-ae40066c-31b5-11e8-8fa4-080c059fb049.png)


**After:**
![image](https://user-images.githubusercontent.com/167166/37988334-83a799ba-31b5-11e8-9d7b-aa039f9408cf.png)
