### PR TITLE
[Maintenance/UX] Remove pencil icon from incident summary.

### DIFF
--- a/src/components/Incident/IncidentSummary.js
+++ b/src/components/Incident/IncidentSummary.js
@@ -1,8 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import ModeEditIcon from 'material-ui/svg-icons/editor/mode-edit'
 
-import IconButtonStyled from 'components/elements/IconButtonStyled'
 import Engagements from 'components/Engagements'
 import GlobalActions from 'components/Timeline/Playbook/GlobalActions'
 
@@ -55,11 +53,7 @@ const IncidentManagerColumn = (ticket) => [
   (key) =>
     <div key={key}>
       {ticket.imName}
-    </div>,
-  (key) =>
-    <IconButtonStyled tooltip='Edit IM' key={key}>
-      <ModeEditIcon />
-    </IconButtonStyled>
+    </div>
 ]
 
 const noTitleMessage = 'No Title!'


### PR DESCRIPTION
**Before:**
![image](https://user-images.githubusercontent.com/167166/37998327-0f62677e-31d3-11e8-82d3-9db5f224a58e.png)

**After:**
![image](https://user-images.githubusercontent.com/167166/37998348-23edbfd6-31d3-11e8-8ae4-7997d5f1a5ce.png)
