### PR TITLE
Display ticket severity

### DIFF
--- a/src/components/Incident/IncidentSummary.js
+++ b/src/components/Incident/IncidentSummary.js
@@ -40,7 +40,7 @@ const BasicInfoColumn = (ticketSystem, ticket) => [
     <a href={`${ticketSystem.ticketUriPrefix}${ticket.originId}${ticketSystem.ticketUriSuffix}`} key={key} target='_blank'>
       {ticket.originId}
     </a>,
-  (key) => ticket.data && 'severity' in ticket.data 
+  (key) => ticket.data && 'severity' in ticket.data
     ? (
       <div key={key}>
         Severity: {ticket.data.severity}

--- a/src/components/Incident/IncidentSummary.js
+++ b/src/components/Incident/IncidentSummary.js
@@ -40,10 +40,13 @@ const BasicInfoColumn = (ticketSystem, ticket) => [
     <a href={`${ticketSystem.ticketUriPrefix}${ticket.originId}${ticketSystem.ticketUriSuffix}`} key={key} target='_blank'>
       {ticket.originId}
     </a>,
-  (key) =>
-    <div key={key}>
-      {ticket.severity}
-    </div>
+  (key) => ticket.data && 'severity' in ticket.data 
+    ? (
+      <div key={key}>
+        Severity: {ticket.data.severity}
+      </div>
+    )
+    : null
 ]
 
 const IncidentManagerColumn = (ticket) => [


### PR DESCRIPTION
**Questions**
* Do we need to be concerned about the scenario where `ticket.data` is `null`? This change accounts for that but it may be redundant. 
* Given that this change is small and we're about to redo layout, is this change acceptable without tests at this time? Or is the presence of branching logic sufficient to justify a test? 

**Summary**
* We previously tried to display severity but were accessing it at the wrong place. This fixes the issue by accessing the severity in the `ticket.data` object and handles situations where the ticket doesn't have a `severity` property. 
* I spoke with Alberto about color coding... that is not in scope for this item

**What it looks like**
![image](https://user-images.githubusercontent.com/2158838/38525752-4f7fdb72-3c08-11e8-83e3-9f5f5ef6a8f4.png)
