### PR TITLE
GoToTicket box is shown on all pages

### DIFF
--- a/src/actions/incidentActions.js
+++ b/src/actions/incidentActions.js
@@ -144,7 +144,7 @@ const postIncidentFetchArgs = (ticketId, ticketSystem) => {
   ]
 }
 
-export const updateIncidentCreationInput = (input) => ({
+export const updateTicketNavigationInput = (input) => ({
   type: UPDATE_INCIDENT_CREATION_INPUT,
   input
 })

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -6,16 +6,17 @@ export const Home = ({ ticket }) => {
   if (ticket && ticket.originId) {
     return <Redirect to={`/tickets/${ticket.originId}`} />
   }
-  return <Redirect to={'/search'} />
 }
 
 export const mapStateToProps = (state) => {
     // this gross thing finds all actual tickets, omitting the refresh metadata, and then picks the most recently visited one out
     // the sort function works because the dates are UTC and thus lexically sortable to start with
   return {
-    ticket: (state.tickets && state.tickets.map) ? Object.values(state.tickets.map).filter(ticket => ticket && ticket.lastRefresh)
-                                        .sort((a, b) => { return (a.lastRefresh > b.lastRefresh) ? -1 : 1 })[0]
-                                        : undefined
+    ticket: (state.tickets && state.tickets.map)
+      ? Object.values(state.tickets.map)
+        .filter(ticket => ticket && ticket.lastRefresh)
+        .sort((a, b) => { return (a.lastRefresh > b.lastRefresh) ? -1 : 1 })[0]
+      : undefined
   }
 }
 

--- a/src/components/Incident/GoToTicket.js
+++ b/src/components/Incident/GoToTicket.js
@@ -3,24 +3,25 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { TextField } from 'material-ui'
 import FlatButtonStyled from 'components/elements/FlatButtonStyled'
-import { updateIncidentCreationInput } from 'actions/incidentActions'
+import { updateTicketNavigationInput } from 'actions/incidentActions'
+import Paper from 'material-ui/Paper'
 
 export const onSubmit = (input, history, dispatch) => () => {
   if (input) {
-    dispatch(updateIncidentCreationInput(''))
+    dispatch(updateTicketNavigationInput(''))
     history.push(/tickets/ + input)
   }
 }
 
-export const CreateIncident = ({input, creationError, history, dispatch}) => <form
-  id='incident-search'
+export const GoToTicketForm = ({input, creationError, history, dispatch}) => <form
+  id='incident-navigation'
   onSubmit={onSubmit(input, history)}
   style={{padding: '16px'}}
 >
   <TextField
-    hintText='Ticket Id of primary ticket'
+    hintText='Ticket Id'
     floatingLabelText='Ticket Id'
-    onChange={(event, newValue) => dispatch(updateIncidentCreationInput(newValue))}
+    onChange={(event, newValue) => dispatch(updateTicketNavigationInput(newValue))}
     value={input}
     errorText={creationError}
   />
@@ -38,11 +39,18 @@ export const mapStateToProps = (state) => {
   }
 }
 
-CreateIncident.propTypes = {
+GoToTicketForm.propTypes = {
   input: PropTypes.string,
   creationError: PropTypes.string,
   history: PropTypes.object.isRequired,
   dispatch: PropTypes.func.isRequired
 }
 
-export default connect(mapStateToProps)(CreateIncident)
+export const ConnectedGoToTicketForm = connect(mapStateToProps)(GoToTicketForm)
+
+export const GoToTicket = () => <Paper zDepth={1}>
+  <span>Go To Ticket:</span>
+  <ConnectedGoToTicketForm />
+</Paper>
+
+export default GoToTicket

--- a/src/components/MainComponent.js
+++ b/src/components/MainComponent.js
@@ -6,7 +6,7 @@ import { Router, Route } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/lib/integration/react'
 
 import createBrowserHistory from 'history/createBrowserHistory'
-import CreateIncident from 'components/Search/CreateIncident'
+import GoToTicketForm from 'components/Incident/GoToTicket'
 import Ticket from 'components/Incident/Ticket'
 import EnsureLoggedInContainer from 'components/Auth/EnsureLoggedIn'
 import incidentRedirect from 'components/Incident/IncidentRedirect'
@@ -31,9 +31,9 @@ export default class MainComponent extends React.Component {
                   <div>
                     { isChromeExtensionBackground() ? <Notifications /> : null }
                     <TopNav />
+                    <Route path='/' component={GoToTicketForm} />
                     <Route exact path='/' component={Home} />
                     <Route exact path='/extension.html' component={Home} />
-                    <Route path='/search' component={CreateIncident} />
                     <Route path='/tickets/:ticketId' component={Ticket} />
                     <Route path='/incidents/:incidentId' component={incidentRedirect} />
                     <Route path='/debug' render={() => <Debug />} />

--- a/test/components/Incident/GoToTicketTest.js
+++ b/test/components/Incident/GoToTicketTest.js
@@ -2,27 +2,34 @@
 import { expect } from 'chai'
 import React from 'react'
 import { TextField } from 'material-ui'
+import Paper from 'material-ui/Paper'
 
 import { GetMockDispatch, GetDispatchRecorder } from 'test/helpers/mockDispatch'
 import { GetMockHistory, GetHistoryRecorder } from 'test/helpers/mockHistory'
 import createComponent from 'test/helpers/shallowRenderHelper'
 
-import { CreateIncident, mapStateToProps, onSubmit } from 'components/Search/CreateIncident'
+import {
+  GoToTicketForm,
+  mapStateToProps,
+  onSubmit,
+  ConnectedGoToTicketForm,
+  GoToTicket
+} from 'components/Incident/GoToTicket'
 import FlatButtonStyled from 'components/elements/FlatButtonStyled'
 
-const setup = (input, creationError) => {
-  let props = {
-    dispatch: () => null,
-    input,
-    creationError
-  }
+describe('GoToTicket', function () {
+  describe('GoToTicketForm render output', function () {
+    const setup = (input, creationError) => {
+      let props = {
+        dispatch: () => null,
+        input,
+        creationError
+      }
 
-  return createComponent(CreateIncident, props)
-}
+      return createComponent(GoToTicketForm, props)
+    }
 
-describe('CreateIncident', function testCreateIncident () {
-  describe('Rendered component', function () {
-    beforeEach(function createIncidentInit () {
+    beforeEach(function () {
       this.testError = 'Test Error'
       this.testInput = '10'
 
@@ -31,7 +38,7 @@ describe('CreateIncident', function testCreateIncident () {
       this.withInput = setup(this.testInput, '')
     })
 
-    it('Should render a form with text field and FlatButtonStyled', function createIncidentRenderForm () {
+    it('Should render a form with text field and FlatButtonStyled', function () {
       expect(this.defaultCase.type).to.equal('form')
       expect(this.defaultCase.props.children[0].type).to.equal(TextField)
       expect(this.defaultCase.props.children[1].type).to.equal(FlatButtonStyled)
@@ -43,12 +50,12 @@ describe('CreateIncident', function testCreateIncident () {
       expect(this.withInput.props.children[1].type).to.equal(FlatButtonStyled)
     })
 
-    it('Should pass props.input to TextField value', function createIncidentDisplayInput () {
+    it('Should pass props.input to TextField value', function () {
       expect(this.defaultCase.props.children[0].props.value).to.equal('')
       expect(this.withInput.props.children[0].props.value).to.equal(this.testInput)
     })
 
-    it('Should pass props.creationError to TextField errorText', function createIncidentDisplayCreationError () {
+    it('Should pass props.creationError to TextField errorText', function () {
       expect(this.defaultCase.props.children[0].props.errorText).to.equal('')
       expect(this.withError.props.children[0].props.errorText).to.equal(this.testError)
     })
@@ -99,45 +106,66 @@ describe('CreateIncident', function testCreateIncident () {
       })
     })
   })
-})
 
-const inputState = {
-  tickets: {
-    map: {
-      1: {id: 100}
-    },
-    systems: {
-      1: {id: 1},
-      2: {id: 2}
-    }
-  },
-  incidents: {
-    creation: {
-      input: 'test input',
-      error: {
-        message: 'test error message'
+  describe('mapStateToProps', function () {
+    const inputState = {
+      tickets: {
+        map: {
+          1: {id: 100}
+        },
+        systems: {
+          1: {id: 1},
+          2: {id: 2}
+        }
+      },
+      incidents: {
+        creation: {
+          input: 'test input',
+          error: {
+            message: 'test error message'
+          }
+        }
       }
     }
-  }
-}
 
-const expectedResult = {
-  input: 'test input',
-  ticketSystem: {
-    id: 1
-  },
-  creationError: 'test error message',
-  incidentActions: {
-    TestKey: 'TestValue'
-  }
-}
-
-describe('CreateIncidentMapStateToProps', () => {
-  it('Should correctly generate an args object from state', () => {
     const result = mapStateToProps(inputState)
 
-    expect(result.input).to.equal(expectedResult.input)
-    expect(result.ticketSystem.id).to.equal(expectedResult.ticketSystem.id)
-    expect(result.creationError).to.equal(expectedResult.creationError)
+    it('Should correctly generate an args object from state', () => {
+      const expectedResult = {
+        input: 'test input',
+        ticketSystem: {
+          id: 1
+        },
+        creationError: 'test error message',
+        incidentActions: {
+          TestKey: 'TestValue'
+        }
+      }
+
+      expect(result.input).to.equal(expectedResult.input)
+      expect(result.ticketSystem.id).to.equal(expectedResult.ticketSystem.id)
+      expect(result.creationError).to.equal(expectedResult.creationError)
+    })
+  })
+
+  describe('GoToTicket render output', function () {
+    const result = createComponent(GoToTicket)
+
+    it('Should be a Paper', function () {
+      expect(result.type).to.equal(Paper)
+    })
+
+    it('Should have a label span as its first child', function () {
+      expect(result.props.children[0].type).to.equal('span')
+    })
+
+    it('Should have ConnectedGoToTicketForm as its second child', function () {
+      expect(result.props.children[1].type).to.equal(ConnectedGoToTicketForm)
+    })
   })
 })
+
+
+
+
+

--- a/test/components/homeTest.js
+++ b/test/components/homeTest.js
@@ -16,17 +16,14 @@ const ticketState = { ticket: {
   lastRefresh: '2017-12-29T20:19:32.407Z'
 }}
 
-describe('Home Container Component', function test () {
-  beforeEach(() => {
-    this.noTicketsExistState = setup(noTicketState, children)
-    this.ticketsExistState = setup(ticketState, children)
+describe('Home Container Component', function () {
+  it('Should return nothing if no tickets', function () {
+    const noTicketsExistState = setup(noTicketState, children)
+    expect(noTicketsExistState).to.be.undefined
   })
-
-  it('Should redirect to search if no tickets', () => {
-    expect(this.noTicketsExistState.props.to).to.equal('/search')
-  })
-  it('Should redirect to most recent ticket if there are tickets', () => {
-    expect(this.ticketsExistState.props.to).to.equal('/tickets/5507')
+  it('Should redirect to most recent ticket if there are tickets', function () {
+    const ticketsExistState = setup(ticketState, children)
+    expect(ticketsExistState.props.to).to.equal('/tickets/5507')
   })
 })
 

--- a/test/reducers/incidentReducersTest.js
+++ b/test/reducers/incidentReducersTest.js
@@ -175,8 +175,8 @@ describe('incidentReducer', function test () {
       this.newInput = 'new input'
       this.failureError = 'testing'
 
-      this.OnUpdateInputFromDefault = creation(creationDefaultState, incidentActions.updateIncidentCreationInput(this.newInput))
-      this.OnUpdateInputFromError = creation(creationWithErrorState, incidentActions.updateIncidentCreationInput(this.newInput))
+      this.OnUpdateInputFromDefault = creation(creationDefaultState, incidentActions.updateTicketNavigationInput(this.newInput))
+      this.OnUpdateInputFromError = creation(creationWithErrorState, incidentActions.updateTicketNavigationInput(this.newInput))
       this.OnTryCreateIncidentFromDefault = creation(creationDefaultState, tryCreateIncident('', {}))
       this.OnTryCreateIncidentFromError = creation(creationWithErrorState, tryCreateIncident('', {}))
       this.OnFailureFromDefault = creation(creationDefaultState, failCreateIncident(this.failureError))


### PR DESCRIPTION
For Task 47549: Replace "Incident Search" page with "Go to Ticket" field.

This is extremely unlikely to be the style/layout we want, but is this the correct functionality? GoToTicket is shown on all pages.